### PR TITLE
WinEventLogXML scenarios for privilege escalation via EventIDs 4720 and 4732

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,3 +1,3 @@
 {
-  "min_cli_version": "0.4.3"
+  "min_cli_version": "0.4.5"
 }

--- a/scenarios/windows/wineventlog/eid4720-4732-new-admin.yaml
+++ b/scenarios/windows/wineventlog/eid4720-4732-new-admin.yaml
@@ -1,0 +1,158 @@
+type: scenario
+description: |
+  Privilege escalation: new local user account created (EventID 4720) then
+  added to the BUILTIN\Administrators group (EventID 4732) on the same host
+  within the 180-minute correlation window. Emits a correlated Security-
+  channel pair where the 4732 Group Name resolves to "Administrators".
+tags: [windows, security, privilege-escalation]
+mitre:
+  tactics: [persistence]
+  techniques: [T1136.001]
+
+state:
+  computer:              gen.hostname(class=windows-server, domain=corp.local)
+  domain_short:          CORP
+  domain_dn:             "DC=corp,DC=local"
+  new_user:              gen.username()
+  new_user_dn:           "CN=${ref.new_user},CN=Users,${ref.domain_dn}"
+  new_user_rid:          gen.int(min=1100, max=9999)
+  new_user_sid:          "S-1-5-21-111222333-444555666-777888999-${ref.new_user_rid}"
+  admin_user:            Administrator
+  admin_sid:             "S-1-5-21-111222333-444555666-777888999-500"
+  admin_logon_id:        "0x79779"
+  host_record_id_create: gen.int(min=200000, max=999999)
+  host_record_id_add:    gen.int(min=200000, max=999999)
+  proc_id:               gen.int(min=600, max=900)
+  thread_id:             gen.int(min=1000, max=4000)
+  time_gap:              "60s" # duration between user account creation and admin group assignment
+
+steps:
+  # Step 1: EventID 4720 — A user account was created.
+  - emit:
+      event_type: windows.wineventlog@v1
+      fields:
+        System:
+          Provider:
+            "@Name": Microsoft-Windows-Security-Auditing
+            "@Guid": "{54849625-5478-4994-A5BA-3E3B0328C30D}"
+          EventID: 4720
+          Version: 0
+          Level: 0
+          Task: 13824
+          Opcode: 0
+          Keywords: "0x8020000000000000"
+          TimeCreated:
+            "@SystemTime": gen.timestamp(format=wineventlog)
+          EventRecordID: ref.host_record_id_create
+          Correlation: {}
+          Execution:
+            "@ProcessID": ref.proc_id
+            "@ThreadID": ref.thread_id
+          Channel: Security
+          Computer: ref.computer
+          Security: {}
+        EventData:
+          Data:
+            - "@Name": TargetUserName
+              "#text": ref.new_user
+            - "@Name": TargetDomainName
+              "#text": ref.domain_short
+            - "@Name": TargetSid
+              "#text": ref.new_user_sid
+            - "@Name": SubjectUserSid
+              "#text": ref.admin_sid
+            - "@Name": SubjectUserName
+              "#text": ref.admin_user
+            - "@Name": SubjectDomainName
+              "#text": ref.domain_short
+            - "@Name": SubjectLogonId
+              "#text": ref.admin_logon_id
+            - "@Name": PrivilegeList
+              "#text": "-"
+            - "@Name": SamAccountName
+              "#text": ref.new_user
+            - "@Name": DisplayName
+              "#text": "-"
+            - "@Name": UserPrincipalName
+              "#text": "-"
+            - "@Name": HomeDirectory
+              "#text": "-"
+            - "@Name": HomePath
+              "#text": "-"
+            - "@Name": ScriptPath
+              "#text": "-"
+            - "@Name": ProfilePath
+              "#text": "-"
+            - "@Name": UserWorkstations
+              "#text": "-"
+            - "@Name": PasswordLastSet
+              "#text": "-"
+            - "@Name": AccountExpires
+              "#text": "-"
+            - "@Name": PrimaryGroupId
+              "#text": "513"
+            - "@Name": AllowedToDelegateTo
+              "#text": "-"
+            - "@Name": OldUacValue
+              "#text": "0x0"
+            - "@Name": NewUacValue
+              "#text": "0x15"
+            - "@Name": UserAccountControl
+              "#text": "%%2080 %%2082 %%2084"
+            - "@Name": UserParameters
+              "#text": "-"
+            - "@Name": SidHistory
+              "#text": "-"
+            - "@Name": LogonHours
+              "#text": All
+
+  # Short administrative gap between account creation and group assignment.
+  - wait:
+      duration: ref.time_gap
+
+  # Step 2: EventID 4732 — member added to BUILTIN\Administrators.
+  - emit:
+      event_type: windows.wineventlog@v1
+      fields:
+        System:
+          Provider:
+            "@Name": Microsoft-Windows-Security-Auditing
+            "@Guid": "{54849625-5478-4994-A5BA-3E3B0328C30D}"
+          EventID: 4732
+          Version: 0
+          Level: 0
+          Task: 13826
+          Opcode: 0
+          Keywords: "0x8020000000000000"
+          TimeCreated:
+            "@SystemTime": gen.timestamp(format=wineventlog)
+          EventRecordID: ref.host_record_id_add
+          Correlation: {}
+          Execution:
+            "@ProcessID": ref.proc_id
+            "@ThreadID": ref.thread_id
+          Channel: Security
+          Computer: ref.computer
+          Security: {}
+        EventData:
+          Data:
+            - "@Name": MemberName
+              "#text": ref.new_user_dn
+            - "@Name": MemberSid
+              "#text": ref.new_user_sid
+            - "@Name": TargetUserName
+              "#text": Administrators
+            - "@Name": TargetDomainName
+              "#text": Builtin
+            - "@Name": TargetSid
+              "#text": "S-1-5-32-544"
+            - "@Name": SubjectUserSid
+              "#text": ref.admin_sid
+            - "@Name": SubjectUserName
+              "#text": ref.admin_user
+            - "@Name": SubjectDomainName
+              "#text": ref.domain_short
+            - "@Name": SubjectLogonId
+              "#text": ref.admin_logon_id
+            - "@Name": PrivilegeList
+              "#text": "-"

--- a/scenarios/windows/wineventlog/eid4720-user-only.yaml
+++ b/scenarios/windows/wineventlog/eid4720-user-only.yaml
@@ -1,0 +1,99 @@
+type: scenario
+description: |
+  Benign user-account creation (EventID 4720) without a subsequent
+  add-to-Administrators event. Models routine user provisioning — creates
+  a Security 4720 but never follows up with a 4732 to BUILTIN\Administrators,
+  so the "Detect New Local Admin account" correlation should NOT fire.
+tags: [windows, security, benign]
+
+state:
+  computer:          gen.hostname(class=windows-server, domain=corp.local)
+  domain_short:      CORP
+  new_user:          gen.username()
+  new_user_rid:      gen.int(min=1100, max=9999)
+  new_user_sid:      "S-1-5-21-111222333-444555666-777888999-${ref.new_user_rid}"
+  admin_user:        Administrator
+  admin_sid:         "S-1-5-21-111222333-444555666-777888999-500"
+  admin_logon_id:    "0x79779"
+  host_record_id:    gen.int(min=200000, max=999999)
+  proc_id:           gen.int(min=600, max=900)
+  thread_id:         gen.int(min=1000, max=4000)
+
+steps:
+  - emit:
+      event_type: windows.wineventlog@v1
+      fields:
+        System:
+          Provider:
+            "@Name": Microsoft-Windows-Security-Auditing
+            "@Guid": "{54849625-5478-4994-A5BA-3E3B0328C30D}"
+          EventID: 4720
+          Version: 0
+          Level: 0
+          Task: 13824
+          Opcode: 0
+          Keywords: "0x8020000000000000"
+          TimeCreated:
+            "@SystemTime": gen.timestamp(format=wineventlog)
+          EventRecordID: ref.host_record_id
+          Correlation: {}
+          Execution:
+            "@ProcessID": ref.proc_id
+            "@ThreadID": ref.thread_id
+          Channel: Security
+          Computer: ref.computer
+          Security: {}
+        EventData:
+          Data:
+            - "@Name": TargetUserName
+              "#text": ref.new_user
+            - "@Name": TargetDomainName
+              "#text": ref.domain_short
+            - "@Name": TargetSid
+              "#text": ref.new_user_sid
+            - "@Name": SubjectUserSid
+              "#text": ref.admin_sid
+            - "@Name": SubjectUserName
+              "#text": ref.admin_user
+            - "@Name": SubjectDomainName
+              "#text": ref.domain_short
+            - "@Name": SubjectLogonId
+              "#text": ref.admin_logon_id
+            - "@Name": PrivilegeList
+              "#text": "-"
+            - "@Name": SamAccountName
+              "#text": ref.new_user
+            - "@Name": DisplayName
+              "#text": "-"
+            - "@Name": UserPrincipalName
+              "#text": "-"
+            - "@Name": HomeDirectory
+              "#text": "-"
+            - "@Name": HomePath
+              "#text": "-"
+            - "@Name": ScriptPath
+              "#text": "-"
+            - "@Name": ProfilePath
+              "#text": "-"
+            - "@Name": UserWorkstations
+              "#text": "-"
+            - "@Name": PasswordLastSet
+              "#text": "-"
+            - "@Name": AccountExpires
+              "#text": "-"
+            - "@Name": PrimaryGroupId
+              "#text": "513"
+            - "@Name": AllowedToDelegateTo
+              "#text": "-"
+            - "@Name": OldUacValue
+              "#text": "0x0"
+            - "@Name": NewUacValue
+              "#text": "0x15"
+            - "@Name": UserAccountControl
+              "#text": "%%2080 %%2082 %%2084"
+            - "@Name": UserParameters
+              "#text": "-"
+            - "@Name": SidHistory
+              "#text": "-"
+            - "@Name": LogonHours
+              "#text": All

--- a/scenarios/windows/wineventlog/eid4732-add-to-users.yaml
+++ b/scenarios/windows/wineventlog/eid4732-add-to-users.yaml
@@ -1,0 +1,121 @@
+type: scenario
+description: |
+  Benign group membership change (EventID 4732) adding a newly-created user
+  (EventID 4720) to a non-privileged local group ("Users") on the same host.
+  Because the target group is not "Administrators", the "Detect New Local
+  Admin account" correlation should NOT fire even though both EventCodes
+  appear within the 180-minute window.
+tags: [windows, security, benign]
+
+state:
+  computer:              gen.hostname(class=windows-server, domain=corp.local)
+  domain_short:          CORP
+  domain_dn:             "DC=corp,DC=local"
+  new_user:              gen.username()
+  new_user_rid:          gen.int(min=1100, max=9999)
+  new_user_sid:          "S-1-5-21-111222333-444555666-777888999-${ref.new_user_rid}"
+  new_user_dn:           "CN=${ref.new_user},CN=Users,${ref.domain_dn}"
+  admin_user:            Administrator
+  admin_sid:             "S-1-5-21-111222333-444555666-777888999-500"
+  admin_logon_id:        "0x79779"
+  host_record_id_create: gen.int(min=200000, max=999999)
+  host_record_id_add:    gen.int(min=200000, max=999999)
+  proc_id:               gen.int(min=600, max=900)
+  thread_id:             gen.int(min=1000, max=4000)
+
+steps:
+  - emit:
+      event_type: windows.wineventlog@v1
+      fields:
+        System:
+          Provider:
+            "@Name": Microsoft-Windows-Security-Auditing
+            "@Guid": "{54849625-5478-4994-A5BA-3E3B0328C30D}"
+          EventID: 4720
+          Version: 0
+          Level: 0
+          Task: 13824
+          Opcode: 0
+          Keywords: "0x8020000000000000"
+          TimeCreated:
+            "@SystemTime": gen.timestamp(format=wineventlog)
+          EventRecordID: ref.host_record_id_create
+          Correlation: {}
+          Execution:
+            "@ProcessID": ref.proc_id
+            "@ThreadID": ref.thread_id
+          Channel: Security
+          Computer: ref.computer
+          Security: {}
+        EventData:
+          Data:
+            - "@Name": TargetUserName
+              "#text": ref.new_user
+            - "@Name": TargetDomainName
+              "#text": ref.domain_short
+            - "@Name": TargetSid
+              "#text": ref.new_user_sid
+            - "@Name": SubjectUserSid
+              "#text": ref.admin_sid
+            - "@Name": SubjectUserName
+              "#text": ref.admin_user
+            - "@Name": SubjectDomainName
+              "#text": ref.domain_short
+            - "@Name": SubjectLogonId
+              "#text": ref.admin_logon_id
+            - "@Name": PrivilegeList
+              "#text": "-"
+            - "@Name": SamAccountName
+              "#text": ref.new_user
+            - "@Name": PrimaryGroupId
+              "#text": "513"
+
+  - wait:
+      duration: 60s
+
+  # 4732 but target group is "Users", not "Administrators" — should not fire.
+  - emit:
+      event_type: windows.wineventlog@v1
+      fields:
+        System:
+          Provider:
+            "@Name": Microsoft-Windows-Security-Auditing
+            "@Guid": "{54849625-5478-4994-A5BA-3E3B0328C30D}"
+          EventID: 4732
+          Version: 0
+          Level: 0
+          Task: 13826
+          Opcode: 0
+          Keywords: "0x8020000000000000"
+          TimeCreated:
+            "@SystemTime": gen.timestamp(format=wineventlog)
+          EventRecordID: ref.host_record_id_add
+          Correlation: {}
+          Execution:
+            "@ProcessID": ref.proc_id
+            "@ThreadID": ref.thread_id
+          Channel: Security
+          Computer: ref.computer
+          Security: {}
+        EventData:
+          Data:
+            - "@Name": MemberName
+              "#text": ref.new_user_dn
+            - "@Name": MemberSid
+              "#text": ref.new_user_sid
+            - "@Name": TargetUserName
+              "#text": Users
+            - "@Name": TargetDomainName
+              "#text": Builtin
+            - "@Name": TargetSid
+              "#text": "S-1-5-32-545"
+            - "@Name": SubjectUserSid
+              "#text": ref.admin_sid
+            - "@Name": SubjectUserName
+              "#text": ref.admin_user
+            - "@Name": SubjectDomainName
+              "#text": ref.domain_short
+            - "@Name": SubjectLogonId
+              "#text": ref.admin_logon_id
+            - "@Name": PrivilegeList
+              "#text": "-"


### PR DESCRIPTION
Add scenarios for detecting new local admin account and benign user operations

- Add `eid4720-4732-new-admin.yaml`: Detects privilege escalation via EventIDs 4720 and 4732 (new user added to Administrators group).
- Add `eid4732-add-to-users.yaml`: Models benign group membership change (EventID 4732) to non-privileged group ("Users").
- Add `eid4720-user-only.yaml`: Simulates benign standalone user creation (EventID 4720) without escalation.
- Update `library.json` to require CLI version 0.4.5.