### PR TITLE
Add scenario and job for 3CX supply chain attack detection validation

### DIFF
--- a/jobs/splunk/windows/sysmon/dns-query/3cx-supply-chain-attack-network-indicators.yaml
+++ b/jobs/splunk/windows/sysmon/dns-query/3cx-supply-chain-attack-network-indicators.yaml
@@ -9,7 +9,7 @@ description: |
   present on raw events — so the workload uses result_row_correlation: each
   alert row is matched back to its scenario by the SPL's group-by tuple.
 
-tags: [3cx, CVE-2023-29059]
+tags: [3cx, cve-2023-29059]
 mitre:
   tactics: [initial-access]
   techniques: ["T1195.002"]

--- a/jobs/splunk/windows/sysmon/dns-query/3cx-supply-chain-attack-network-indicators.yaml
+++ b/jobs/splunk/windows/sysmon/dns-query/3cx-supply-chain-attack-network-indicators.yaml
@@ -1,0 +1,43 @@
+type: job
+description: |
+  Validates the ESCU "3CX Supply Chain Attack Network Indicators" detection
+  (T1195.002).
+
+  The SPL aggregates Sysmon DNS queries via the Network_Resolution datamodel
+  and filters them through the curated `3cx_ioc_domains` lookup. Per-event
+  correlation is impossible — the lookup adds an `isIOC` field that is not
+  present on raw events — so the workload uses result_row_correlation: each
+  alert row is matched back to its scenario by the SPL's group-by tuple.
+
+tags: [3cx, CVE-2023-29059]
+mitre:
+  tactics: [initial-access]
+  techniques: ["T1195.002"]
+
+state:
+  # Lifted to job-scope so detection.correlation can reference them. The
+  # scenario keeps its own defaults; bindings below project these values
+  # into the workload.
+  query_name: "www.3cx.com"
+  computer:   gen.hostname(class=windows-workstation, domain=corp.local)
+
+workloads:
+  - scenario: scenarios/windows/sysmon/dns-query/3cx-ioc-dns-query
+    bindings:
+      query_name: ref.query_name
+      computer:   ref.computer
+    detection:
+      expected: alert
+      attack: "3CX supply chain — DNS query to a known-IOC domain"
+      mitre:
+        tactics: [initial-access]
+        techniques: ["T1195.002"]
+      correlation:
+        # Network_Resolution group-by, post-`drop_dm_object_name(DNS)`. The
+        # SPL emits one result row per DNS answer (the QueryResults
+        # multivalue is split), so `answer`/`answer_count` are excluded —
+        # all rows from this workload share `query`, `src`, and the
+        # TA-supplied `vendor_product` constant.
+        query:          ref.query_name
+        src:            ref.computer
+        vendor_product: "Microsoft Sysmon"

--- a/scenarios/windows/sysmon/dns-query/3cx-ioc-dns-query.yaml
+++ b/scenarios/windows/sysmon/dns-query/3cx-ioc-dns-query.yaml
@@ -7,7 +7,7 @@ description: |
   query as an indicator of the supply-chain compromise; this scenario
   emits the underlying Sysmon DnsQuery event the IOC list is matched
   against.
-tags: [eid22, attack, 3cx, CVE-2023-29059]
+tags: [eid22, attack, 3cx, cve-2023-29059]
 mitre:
   tactics: [initial-access]
   techniques: [T1195.002]

--- a/scenarios/windows/sysmon/dns-query/3cx-ioc-dns-query.yaml
+++ b/scenarios/windows/sysmon/dns-query/3cx-ioc-dns-query.yaml
@@ -1,0 +1,74 @@
+type: scenario
+description: |
+  3CX supply chain attack — DNS query to a 3CX-affiliated domain
+  (Sysmon EID 22, DnsQuery). Models a host that resolves www.3cx.com,
+  which appears on the curated 3CX IOC list alongside the trojanized
+  client's C2 infrastructure. The detection treats any matching DNS
+  query as an indicator of the supply-chain compromise; this scenario
+  emits the underlying Sysmon DnsQuery event the IOC list is matched
+  against.
+tags: [eid22, attack, 3cx, CVE-2023-29059]
+mitre:
+  tactics: [initial-access]
+  techniques: [T1195.002]
+
+state:
+  computer:        gen.hostname(class=windows-workstation, domain=corp.local)
+  sysmon_pid:      gen.int(min=1000, max=4000)
+  sysmon_tid:      gen.int(min=1000, max=9999)
+  process_pid:     gen.int(min=1000, max=9999)
+  process_guid_raw: gen.uuid()
+  process_guid:    "{${ref.process_guid_raw}}"
+  user:            gen.username()
+  user_qualified:  "CORP\\${ref.user}"
+  image:           "C:\\Program Files\\Mozilla Firefox\\firefox.exe"
+  query_name:      "www.3cx.com"
+  query_status:    "0"
+  query_results:   "104.18.15.54;104.18.14.54;"
+  event_record_id: gen.int(min=5000, max=99999)
+
+steps:
+  - emit:
+      event_type: windows.wineventlog@v1
+      fields:
+        System:
+          Provider:
+            "@Name": Microsoft-Windows-Sysmon
+            "@Guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}"
+          EventID: 22
+          Version: 5
+          Level: 4
+          Task: 22
+          Opcode: 0
+          Keywords: "0x8000000000000000"
+          TimeCreated:
+            "@SystemTime": gen.timestamp(format=wineventlog)
+          EventRecordID: ref.event_record_id
+          Correlation: {}
+          Execution:
+            "@ProcessID": ref.sysmon_pid
+            "@ThreadID": ref.sysmon_tid
+          Channel: Microsoft-Windows-Sysmon/Operational
+          Computer: ref.computer
+          Security:
+            "@UserID": S-1-5-18
+        EventData:
+          Data:
+            - "@Name": RuleName
+              "#text": "-"
+            - "@Name": UtcTime
+              "#text": gen.timestamp(format=sysmon)
+            - "@Name": ProcessGuid
+              "#text": ref.process_guid
+            - "@Name": ProcessId
+              "#text": ref.process_pid
+            - "@Name": QueryName
+              "#text": ref.query_name
+            - "@Name": QueryStatus
+              "#text": ref.query_status
+            - "@Name": QueryResults
+              "#text": ref.query_results
+            - "@Name": Image
+              "#text": ref.image
+            - "@Name": User
+              "#text": ref.user_qualified


### PR DESCRIPTION
- Add `3cx-ioc-dns-query.yaml` scenario: Models Sysmon EID 22 events for DNS queries to known 3CX IOC domains (e.g., www.3cx.com).
- Add `3cx-supply-chain-attack-network-indicators.yaml` job: Validates ESCU detection "3CX Supply Chain Attack Network Indicators" (T1195.002) based on the Network_Resolution datamodel.
- Bindings include IOC-based correlation fields (`query_name`, `computer`) for alert validation.