### PR TITLE
"Active Setup Registry Autostart" scenario & job

### DIFF
--- a/jobs/splunk/windows/sysmon/registry/active-setup-registry-autostart.yaml
+++ b/jobs/splunk/windows/sysmon/registry/active-setup-registry-autostart.yaml
@@ -1,0 +1,38 @@
+type: job
+description: |
+  Validates the ESCU "Active Setup Registry Autostart" detection (T1547.014).
+
+  The SPL aggregates Sysmon registry-set events via the Endpoint.Registry
+  datamodel and filters on `registry_value_name="StubPath"` AND
+  `registry_path="*\SOFTWARE\Microsoft\Active Setup\Installed Components*"`.
+  Per-event correlation works end-to-end: the TA rewrites
+  `| tstats … FROM datamodel=Endpoint.Registry … by Registry.* | drop_dm_object_name(Registry)`
+  to `| datamodel Endpoint Registry search | search … | stats … by Registry.* | rename Registry.* AS *`
+  for verbose rerun, and the resulting raw events are intersected against
+  the run's delivered events on the event-type's correlation tuple.
+
+  Attack workload writes StubPath under a freshly-generated GUID — fires.
+  Benign workload writes a non-Active-Setup key (W32Time service state) —
+  exercises the same EID 13 emission path without matching the SPL filter,
+  so it must NOT fire.
+
+mitre:
+  tactics: [persistence, privilege-escalation]
+  techniques: [T1547.014]
+
+workloads:
+  # Attack: regedit writes \Active Setup\Installed Components\{GUID}\StubPath
+  # pointing at a user-writable payload — should fire.
+  - scenario: scenarios/windows/sysmon/registry/active-setup-stubpath
+    detection:
+      expected: alert
+      attack: "Active Setup Registry Autostart"
+      mitre:
+        tactics: [persistence, privilege-escalation]
+        techniques: [T1547.014]
+
+  # Benign: W32Time service updating SecureTimeConfidence — same EID 13
+  # SetValue path, non-Active-Setup target, must NOT fire.
+  - scenario: scenarios/windows/sysmon/registry/w32time-config-set
+    detection:
+      expected: none

--- a/scenarios/windows/sysmon/registry/active-setup-stubpath.yaml
+++ b/scenarios/windows/sysmon/registry/active-setup-stubpath.yaml
@@ -20,10 +20,11 @@ state:
   process_guid_raw:   gen.uuid()
   process_guid:       "{${ref.process_guid_raw}}"
   image:              "C:\\Windows\\regedit.exe"
+  username:           gen.username()
   component_guid_raw: gen.uuid()
   component_guid:     "{${ref.component_guid_raw}}"
   target_object:      "HKLM\\SOFTWARE\\Microsoft\\Active Setup\\Installed Components\\${ref.component_guid}\\StubPath"
-  details:            '"C:\Temp\evil_spooler.dll"'
+  details:            '"C:\Users\${ref.username}\AppData\Local\Temp\evil_spooler.dll"'
   event_record_id:    gen.int(min=5000, max=99999)
 
 steps:

--- a/scenarios/windows/sysmon/registry/active-setup-stubpath.yaml
+++ b/scenarios/windows/sysmon/registry/active-setup-stubpath.yaml
@@ -1,0 +1,71 @@
+type: scenario
+description: |
+  Active Setup persistence: Sysmon EID 13 (RegistryEvent value-set) writing
+  the StubPath value under HKLM\SOFTWARE\Microsoft\Active Setup\Installed
+  Components\{GUID}\. Logon-time autostart for any interactive user;
+  legitimate Active Setup components are installer-provisioned during OS
+  setup, so a runtime StubPath write — especially one pointing at a
+  user-writable location — is high-signal for T1547.014 persistence /
+  privilege escalation.
+tags: [eid13, attack]
+mitre:
+  tactics: [persistence, privilege-escalation]
+  techniques: [T1547.014]
+
+state:
+  computer:           gen.hostname(class=windows-workstation, domain=corp.local)
+  sysmon_pid:         gen.int(min=1000, max=4000)
+  sysmon_tid:         gen.int(min=1000, max=9999)
+  process_pid:        gen.int(min=1000, max=9999)
+  process_guid_raw:   gen.uuid()
+  process_guid:       "{${ref.process_guid_raw}}"
+  image:              "C:\\Windows\\regedit.exe"
+  component_guid_raw: gen.uuid()
+  component_guid:     "{${ref.component_guid_raw}}"
+  target_object:      "HKLM\\SOFTWARE\\Microsoft\\Active Setup\\Installed Components\\${ref.component_guid}\\StubPath"
+  details:            '"C:\Temp\evil_spooler.dll"'
+  event_record_id:    gen.int(min=5000, max=99999)
+
+steps:
+  - emit:
+      event_type: windows.wineventlog@v1
+      fields:
+        System:
+          Provider:
+            "@Name": Microsoft-Windows-Sysmon
+            "@Guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}"
+          EventID: 13
+          Version: 2
+          Level: 4
+          Task: 13
+          Opcode: 0
+          Keywords: "0x8000000000000000"
+          TimeCreated:
+            "@SystemTime": gen.timestamp(format=wineventlog)
+          EventRecordID: ref.event_record_id
+          Correlation: {}
+          Execution:
+            "@ProcessID": ref.sysmon_pid
+            "@ThreadID": ref.sysmon_tid
+          Channel: Microsoft-Windows-Sysmon/Operational
+          Computer: ref.computer
+          Security:
+            "@UserID": S-1-5-18
+        EventData:
+          Data:
+            - "@Name": RuleName
+              "#text": "-"
+            - "@Name": EventType
+              "#text": SetValue
+            - "@Name": UtcTime
+              "#text": gen.timestamp(format=sysmon)
+            - "@Name": ProcessGuid
+              "#text": ref.process_guid
+            - "@Name": ProcessId
+              "#text": ref.process_pid
+            - "@Name": Image
+              "#text": ref.image
+            - "@Name": TargetObject
+              "#text": ref.target_object
+            - "@Name": Details
+              "#text": ref.details

--- a/scenarios/windows/sysmon/registry/w32time-config-set.yaml
+++ b/scenarios/windows/sysmon/registry/w32time-config-set.yaml
@@ -1,0 +1,67 @@
+type: scenario
+description: |
+  Benign Sysmon EID 13 (RegistryEvent value-set): the Windows Time service
+  updating its SecureTimeConfidence state under
+  HKLM\System\CurrentControlSet\Services\W32Time. Exercises the same
+  registry-set emission path as the Active Setup attack but writes to a
+  non-Active-Setup key with a non-StubPath value name, so it should NOT
+  fire the "Active Setup Registry Autostart" detection. Composes with
+  attack scenarios in jobs to test detection specificity / false-positive
+  resistance.
+tags: [eid13, benign]
+
+state:
+  computer:         gen.hostname(class=windows-workstation, domain=corp.local)
+  sysmon_pid:       gen.int(min=1000, max=4000)
+  sysmon_tid:       gen.int(min=1000, max=9999)
+  process_pid:      gen.int(min=400, max=900)
+  process_guid_raw: gen.uuid()
+  process_guid:     "{${ref.process_guid_raw}}"
+  image:            "C:\\Windows\\system32\\lsass.exe"
+  target_object:    "HKLM\\System\\CurrentControlSet\\Services\\W32Time\\SecureTimeLimits\\RunTime\\SecureTimeConfidence"
+  details:          "DWORD (0x00000006)"
+  event_record_id:  gen.int(min=5000, max=99999)
+
+steps:
+  - emit:
+      event_type: windows.wineventlog@v1
+      fields:
+        System:
+          Provider:
+            "@Name": Microsoft-Windows-Sysmon
+            "@Guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}"
+          EventID: 13
+          Version: 2
+          Level: 4
+          Task: 13
+          Opcode: 0
+          Keywords: "0x8000000000000000"
+          TimeCreated:
+            "@SystemTime": gen.timestamp(format=wineventlog)
+          EventRecordID: ref.event_record_id
+          Correlation: {}
+          Execution:
+            "@ProcessID": ref.sysmon_pid
+            "@ThreadID": ref.sysmon_tid
+          Channel: Microsoft-Windows-Sysmon/Operational
+          Computer: ref.computer
+          Security:
+            "@UserID": S-1-5-18
+        EventData:
+          Data:
+            - "@Name": RuleName
+              "#text": "-"
+            - "@Name": EventType
+              "#text": SetValue
+            - "@Name": UtcTime
+              "#text": gen.timestamp(format=sysmon)
+            - "@Name": ProcessGuid
+              "#text": ref.process_guid
+            - "@Name": ProcessId
+              "#text": ref.process_pid
+            - "@Name": Image
+              "#text": ref.image
+            - "@Name": TargetObject
+              "#text": ref.target_object
+            - "@Name": Details
+              "#text": ref.details

--- a/scenarios/windows/sysmon/registry/w32time-config-set.yaml
+++ b/scenarios/windows/sysmon/registry/w32time-config-set.yaml
@@ -17,7 +17,7 @@ state:
   process_pid:      gen.int(min=400, max=900)
   process_guid_raw: gen.uuid()
   process_guid:     "{${ref.process_guid_raw}}"
-  image:            "C:\\Windows\\system32\\lsass.exe"
+  image:            "C:\\Windows\\System32\\svchost.exe"
   target_object:    "HKLM\\System\\CurrentControlSet\\Services\\W32Time\\SecureTimeLimits\\RunTime\\SecureTimeConfidence"
   details:          "DWORD (0x00000006)"
   event_record_id:  gen.int(min=5000, max=99999)


### PR DESCRIPTION

- Add `active-setup-registry-autostart.yaml` job: Validates ESCU detection (T1547.014) using Sysmon registry events.
- Add `active-setup-stubpath.yaml` scenario: Models malicious StubPath writes for persistence via Active Setup GUID components.
- Add `w32time-config-set.yaml` scenario: Models benign key modification under HKLM\System\CurrentControlSet\Services\W32Time to test detection specificity.
- Ensure robust validation of detection accuracy and false-positive resistance.