### PR TITLE
Add Sysmon validation for Network Discovery firewall changes

### DIFF
--- a/jobs/splunk/windows/sysmon/process-create/allow-file-and-printing-sharing-in-firewall.yaml
+++ b/jobs/splunk/windows/sysmon/process-create/allow-file-and-printing-sharing-in-firewall.yaml
@@ -1,19 +1,19 @@
 type: job
 description: |
   Validates the ESCU "Allow File And Printing Sharing In Firewall"
-  detection (T1562.007).
+  detection (T1562.004).
 
   An attack workload emits a Sysmon EID 1 event whose CommandLine is
   `netsh advfirewall firewall set rule group="File and Printer Sharing"
   new enable=Yes` — the conditions the detection filters on. Ransomware
   families (BlackByte, Hellcat, REvil) re-enable this firewall group to
   broaden lateral discovery before encrypting reachable shares. A benign
-  workload exercises the adjacent `group="Network Discovery"` netsh
-  edit, which must NOT trigger the detection.
+  workload exercises a netsh firewall inspection command that must NOT
+  trigger the detection.
 
 mitre:
   tactics: [defense-evasion]
-  techniques: [T1562.007]
+  techniques: [T1562.004]
 
 workloads:
   # Attack: re-enable the "File and Printer Sharing" firewall group via netsh — should fire.
@@ -23,10 +23,9 @@ workloads:
       attack: "Allow File And Printing Sharing In Firewall"
       mitre:
         tactics: [defense-evasion]
-        techniques: [T1562.007]
+        techniques: [T1562.004]
 
-  # Benign: re-enable the "Network Discovery" firewall group — adjacent
-  # but distinct group; must NOT fire.
-  - scenario: scenarios/windows/sysmon/process-create/netsh-allow-net-discovery
+  # Benign: inspect firewall rules via netsh without enabling a group.
+  - scenario: scenarios/windows/sysmon/process-create/netsh-firewall-show-rules
     detection:
       expected: none

--- a/jobs/splunk/windows/sysmon/process-create/allow-network-discovery-in-firewall.yaml
+++ b/jobs/splunk/windows/sysmon/process-create/allow-network-discovery-in-firewall.yaml
@@ -1,0 +1,22 @@
+type: job
+description: |
+  Validates the ESCU "Allow Network Discovery In Firewall" detection
+  (T1562.004).
+
+  The workload emits a Sysmon EID 1 event whose CommandLine invokes
+  `netsh advfirewall firewall set rule group="Network Discovery" new
+  enable=Yes`, matching the detection's Endpoint.Processes filters.
+
+mitre:
+  tactics: [defense-evasion]
+  techniques: [T1562.004]
+
+workloads:
+  # Attack: enable the "Network Discovery" firewall group via netsh.
+  - scenario: scenarios/windows/sysmon/process-create/netsh-allow-net-discovery
+    detection:
+      expected: alert
+      attack: "Allow Network Discovery In Firewall"
+      mitre:
+        tactics: [defense-evasion]
+        techniques: [T1562.004]

--- a/scenarios/windows/sysmon/process-create/netsh-allow-file-and-printer-sharing.yaml
+++ b/scenarios/windows/sysmon/process-create/netsh-allow-file-and-printer-sharing.yaml
@@ -9,7 +9,7 @@ description: |
 tags: [eid1]
 mitre:
   tactics: [defense-evasion]
-  techniques: [T1562.007]
+  techniques: [T1562.004]
 
 state:
   computer:            gen.hostname(class=windows-workstation, domain=corp.local)

--- a/scenarios/windows/sysmon/process-create/netsh-firewall-show-rules.yaml
+++ b/scenarios/windows/sysmon/process-create/netsh-firewall-show-rules.yaml
@@ -1,15 +1,11 @@
 type: scenario
 description: |
-  Defense evasion: an adversary process invokes `netsh.exe advfirewall
-  firewall set rule group="Network Discovery" new enable=Yes` to enable
-  the Network Discovery firewall group. Sysmon EID 1 records the
-  process creation with `Image`/`OriginalFileName` set to netsh.exe and
-  a command line containing the firewall group, `enable`, and `Yes`
-  tokens.
+  Benign administrative inspection: an operator invokes `netsh.exe
+  advfirewall firewall show rule name=all` to list firewall rules without
+  enabling or modifying any firewall group. Sysmon EID 1 records the
+  netsh.exe process creation and command line. This is a quiet control for
+  detections that require `enable=Yes` firewall group changes.
 tags: [eid1]
-mitre:
-  tactics: [defense-evasion]
-  techniques: [T1562.004]
 
 state:
   computer:            gen.hostname(class=windows-workstation, domain=corp.local)
@@ -29,7 +25,7 @@ state:
   user:                "${ref.user_domain}\\${ref.username}"
   image:               C:\Windows\System32\netsh.exe
   original_file_name:  netsh.exe
-  command_line:        '"C:\Windows\System32\netsh.exe" advfirewall firewall set rule group="Network Discovery" new enable=Yes'
+  command_line:        '"C:\Windows\System32\netsh.exe" advfirewall firewall show rule name=all'
   current_directory:   "C:\\Users\\${ref.username}\\"
   parent_image:        C:\Windows\System32\cmd.exe
   parent_command_line: C:\Windows\system32\cmd.exe
@@ -76,7 +72,7 @@ steps:
             - "@Name": Description
               "#text": Network Command Shell
             - "@Name": Product
-              "#text": "Microsoft® Windows® Operating System"
+              "#text": Microsoft Windows Operating System
             - "@Name": Company
               "#text": Microsoft Corporation
             - "@Name": OriginalFileName


### PR DESCRIPTION
- Add a Splunk validation job for the ESCU “Allow Network Discovery In Firewall” detection.
- Mark Network Discovery netsh advfirewall behavior as attack-carrying and classify host firewall modification as T1562.004.
- Add a separate benign netsh firewall show rule control so File and Printer Sharing validation no longer reuses an attack scenario as expected: none.