### PR TITLE
Add Allow Operation with Consent Admin detection scenario/job (T1548)

### DIFF
--- a/jobs/splunk/windows/sysmon/registry/allow-operation-with-consent-admin.yaml
+++ b/jobs/splunk/windows/sysmon/registry/allow-operation-with-consent-admin.yaml
@@ -1,6 +1,6 @@
 type: job
 description: |
-  Validates the ESCU "Allow Operation with Consent Admin" detection (T1548).
+  Validates the ESCU "Allow Operation with Consent Admin" detection (T1548.002).
 
   The SPL aggregates Sysmon registry-set events via the Endpoint.Registry
   datamodel and filters on registry_value_name="ConsentPromptBehaviorAdmin" AND
@@ -16,7 +16,7 @@ description: |
 
 mitre:
   tactics: [privilege-escalation, defense-evasion]
-  techniques: [T1548]
+  techniques: [T1548.002]
 
 workloads:
   # Attack: reg.exe sets ConsentPromptBehaviorAdmin=0x00000000 — should fire.
@@ -26,7 +26,7 @@ workloads:
       attack: "Allow Operation with Consent Admin"
       mitre:
         tactics: [privilege-escalation, defense-evasion]
-        techniques: [T1548]
+        techniques: [T1548.002]
 
   # Benign: W32Time service updating SecureTimeConfidence — same EID 13
   # SetValue path, non-Policies/System target, must NOT fire.

--- a/jobs/splunk/windows/sysmon/registry/allow-operation-with-consent-admin.yaml
+++ b/jobs/splunk/windows/sysmon/registry/allow-operation-with-consent-admin.yaml
@@ -11,7 +11,7 @@ description: |
   for verbose rerun, and the resulting raw events are intersected against the
   run's delivered events on the event-type's correlation tuple.
 
-  Attack workload disables UAC consent prompts via ConsentPromptBehaviorAdmin=0x00 — fires.
+  Attack workload disables UAC consent prompts via ConsentPromptBehaviorAdmin=0x00000000 — fires.
   Benign workload writes an unrelated W32Time registry key — exercises the same
   EID 13 emission path without matching the SPL filter, must NOT fire.
 

--- a/jobs/splunk/windows/sysmon/registry/allow-operation-with-consent-admin.yaml
+++ b/jobs/splunk/windows/sysmon/registry/allow-operation-with-consent-admin.yaml
@@ -27,3 +27,9 @@ workloads:
       mitre:
         tactics: [privilege-escalation, defense-evasion]
         techniques: [T1548]
+
+  # Benign: W32Time service updating SecureTimeConfidence — same EID 13
+  # SetValue path, non-Policies/System target, must NOT fire.
+  - scenario: scenarios/windows/sysmon/registry/w32time-config-set
+    detection:
+      expected: none

--- a/jobs/splunk/windows/sysmon/registry/allow-operation-with-consent-admin.yaml
+++ b/jobs/splunk/windows/sysmon/registry/allow-operation-with-consent-admin.yaml
@@ -4,7 +4,8 @@ description: |
 
   The SPL aggregates Sysmon registry-set events via the Endpoint.Registry
   datamodel and filters on registry_value_name="ConsentPromptBehaviorAdmin" AND
-  registry_value_data="0x00000000". Per-event correlation works end-to-end: the TA
+  registry_value_data matching `*0x00000000*` (raw Sysmon Details emit as
+  `DWORD (0x00000000)`). Per-event correlation works end-to-end: the TA
   rewrites `| tstats … FROM datamodel=Endpoint.Registry … by Registry.* | drop_dm_object_name(Registry)`
   to `| datamodel Endpoint Registry search | search … | stats … by Registry.* | rename Registry.* AS *`
   for verbose rerun, and the resulting raw events are intersected against the

--- a/jobs/splunk/windows/sysmon/registry/allow-operation-with-consent-admin.yaml
+++ b/jobs/splunk/windows/sysmon/registry/allow-operation-with-consent-admin.yaml
@@ -1,0 +1,29 @@
+type: job
+description: |
+  Validates the ESCU "Allow Operation with Consent Admin" detection (T1548).
+
+  The SPL aggregates Sysmon registry-set events via the Endpoint.Registry
+  datamodel and filters on registry_value_name="ConsentPromptBehaviorAdmin" AND
+  registry_value_data="0x00000000". Per-event correlation works end-to-end: the TA
+  rewrites `| tstats … FROM datamodel=Endpoint.Registry … by Registry.* | drop_dm_object_name(Registry)`
+  to `| datamodel Endpoint Registry search | search … | stats … by Registry.* | rename Registry.* AS *`
+  for verbose rerun, and the resulting raw events are intersected against the
+  run's delivered events on the event-type's correlation tuple.
+
+  Attack workload disables UAC consent prompts via ConsentPromptBehaviorAdmin=0x00 — fires.
+  Benign workload writes an unrelated W32Time registry key — exercises the same
+  EID 13 emission path without matching the SPL filter, must NOT fire.
+
+mitre:
+  tactics: [privilege-escalation, defense-evasion]
+  techniques: [T1548]
+
+workloads:
+  # Attack: reg.exe sets ConsentPromptBehaviorAdmin=0x00000000 — should fire.
+  - scenario: scenarios/windows/sysmon/registry/consent-prompt-admin-suppress
+    detection:
+      expected: alert
+      attack: "Allow Operation with Consent Admin"
+      mitre:
+        tactics: [privilege-escalation, defense-evasion]
+        techniques: [T1548]

--- a/scenarios/windows/sysmon/registry/consent-prompt-admin-suppress.yaml
+++ b/scenarios/windows/sysmon/registry/consent-prompt-admin-suppress.yaml
@@ -4,12 +4,12 @@ description: |
   to 0x00000000 under HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System.
   This disables UAC elevation prompts for administrator accounts — any process
   running as admin can silently elevate without user interaction, bypassing the
-  default "Prompt for consent" UAC behavior. Fires T1548 privilege-escalation
+  default "Prompt for consent" UAC behavior. Fires T1548.002 privilege-escalation
   and defense-evasion detections.
 tags: [eid13]
 mitre:
   tactics: [privilege-escalation, defense-evasion]
-  techniques: [T1548]
+  techniques: [T1548.002]
 
 state:
   computer:         gen.hostname(class=windows-workstation, domain=corp.local)

--- a/scenarios/windows/sysmon/registry/consent-prompt-admin-suppress.yaml
+++ b/scenarios/windows/sysmon/registry/consent-prompt-admin-suppress.yaml
@@ -18,7 +18,7 @@ state:
   process_pid:      gen.int(min=400, max=9999)
   process_guid_raw: gen.uuid()
   process_guid:     "{${ref.process_guid_raw}}"
-  image:            "C:\\Windows\\system32\\reg.exe"
+  image:            "C:\\Windows\\System32\\reg.exe"
   target_object:    "HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\ConsentPromptBehaviorAdmin"
   details:          "DWORD (0x00000000)"
   event_record_id:  gen.int(min=5000, max=99999)

--- a/scenarios/windows/sysmon/registry/consent-prompt-admin-suppress.yaml
+++ b/scenarios/windows/sysmon/registry/consent-prompt-admin-suppress.yaml
@@ -1,0 +1,68 @@
+type: scenario
+description: |
+  Sysmon EID 13 (RegistryEvent value-set): setting ConsentPromptBehaviorAdmin
+  to 0x00000000 under HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System.
+  This disables UAC elevation prompts for administrator accounts — any process
+  running as admin can silently elevate without user interaction, bypassing the
+  default "Prompt for consent" UAC behavior. Fires T1548 privilege-escalation
+  and defense-evasion detections.
+tags: [eid13]
+mitre:
+  tactics: [privilege-escalation, defense-evasion]
+  techniques: [T1548]
+
+state:
+  computer:         gen.hostname(class=windows-workstation, domain=corp.local)
+  sysmon_pid:       gen.int(min=1000, max=4000)
+  sysmon_tid:       gen.int(min=1000, max=9999)
+  process_pid:      gen.int(min=400, max=9999)
+  process_guid_raw: gen.uuid()
+  process_guid:     "{${ref.process_guid_raw}}"
+  image:            "C:\\Windows\\system32\\reg.exe"
+  target_object:    "HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\ConsentPromptBehaviorAdmin"
+  details:          "DWORD (0x00000000)"
+  event_record_id:  gen.int(min=5000, max=99999)
+
+steps:
+  - emit:
+      event_type: windows.wineventlog@v1
+      fields:
+        System:
+          Provider:
+            "@Name": Microsoft-Windows-Sysmon
+            "@Guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}"
+          EventID: 13
+          Version: 2
+          Level: 4
+          Task: 13
+          Opcode: 0
+          Keywords: "0x8000000000000000"
+          TimeCreated:
+            "@SystemTime": gen.timestamp(format=wineventlog)
+          EventRecordID: ref.event_record_id
+          Correlation: {}
+          Execution:
+            "@ProcessID": ref.sysmon_pid
+            "@ThreadID": ref.sysmon_tid
+          Channel: Microsoft-Windows-Sysmon/Operational
+          Computer: ref.computer
+          Security:
+            "@UserID": S-1-5-18
+        EventData:
+          Data:
+            - "@Name": RuleName
+              "#text": "-"
+            - "@Name": EventType
+              "#text": SetValue
+            - "@Name": UtcTime
+              "#text": gen.timestamp(format=sysmon)
+            - "@Name": ProcessGuid
+              "#text": ref.process_guid
+            - "@Name": ProcessId
+              "#text": ref.process_pid
+            - "@Name": Image
+              "#text": ref.image
+            - "@Name": TargetObject
+              "#text": ref.target_object
+            - "@Name": Details
+              "#text": ref.details


### PR DESCRIPTION
- Add `consent-prompt-admin-suppress.yaml` scenario: Models Sysmon EID 13 for registry modification disabling UAC prompts (`ConsentPromptBehaviorAdmin=0x00000000`) linked to privilege escalation and defense evasion tactics.
- Add `allow-operation-with-consent-admin.yaml` job: Validates ESCU detection by correlating registry-set events using the Endpoint.Registry datamodel.