### PR TITLE
Add AutoAdminLogon registry entry validation scenario/job (T1552.002)

### DIFF
--- a/jobs/splunk/windows/sysmon/registry/auto-admin-logon-registry-entry.yaml
+++ b/jobs/splunk/windows/sysmon/registry/auto-admin-logon-registry-entry.yaml
@@ -18,8 +18,6 @@ description: |
   Benign workload writes a W32Time service state key — exercises the same
   EID 13 emission path without matching the SPL filter, so it must NOT fire.
 
-tags: [blackmatter]
-
 mitre:
   tactics: [credential-access, persistence]
   techniques: [T1552.002]

--- a/jobs/splunk/windows/sysmon/registry/auto-admin-logon-registry-entry.yaml
+++ b/jobs/splunk/windows/sysmon/registry/auto-admin-logon-registry-entry.yaml
@@ -1,0 +1,41 @@
+type: job
+description: |
+  Validates the ESCU "Auto Admin Logon Registry Entry" detection (T1552.002).
+
+  The SPL aggregates Sysmon registry-set events via the Endpoint.Registry
+  datamodel and filters on `registry_value_name=AutoAdminLogon`,
+  `registry_value_data=1`, and
+  `registry_path="*SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon*"`.
+  Per-event correlation works end-to-end: the TA rewrites
+  `| tstats … FROM datamodel=Endpoint.Registry … by Registry.* | drop_dm_object_name(Registry)`
+  to `| datamodel Endpoint Registry search | search … | stats … by Registry.* | rename Registry.* AS *`
+  for verbose rerun, and the resulting raw events are intersected against
+  the run's delivered events on the event-type's correlation tuple.
+
+  Attack workload writes AutoAdminLogon=1 to the Winlogon key via reg.exe
+  (BlackMatter ransomware technique to maintain access after safe-mode
+  reboot) — fires.
+  Benign workload writes a W32Time service state key — exercises the same
+  EID 13 emission path without matching the SPL filter, so it must NOT fire.
+
+tags: [blackmatter]
+
+mitre:
+  tactics: [credential-access, persistence]
+  techniques: [T1552.002]
+
+workloads:
+  # Attack: reg.exe sets AutoAdminLogon=1 in Winlogon — should fire.
+  - scenario: scenarios/windows/sysmon/registry/auto-admin-logon-set
+    detection:
+      expected: alert
+      attack: "AutoAdminLogon registry entry — automatic privileged logon after safe-mode reboot"
+      mitre:
+        tactics: [credential-access, persistence]
+        techniques: [T1552.002]
+
+  # Benign: W32Time updating SecureTimeConfidence — same EID 13 path,
+  # non-Winlogon target, must NOT fire.
+  - scenario: scenarios/windows/sysmon/registry/w32time-config-set
+    detection:
+      expected: none

--- a/scenarios/windows/sysmon/registry/auto-admin-logon-set.yaml
+++ b/scenarios/windows/sysmon/registry/auto-admin-logon-set.yaml
@@ -1,0 +1,67 @@
+type: scenario
+description: |
+  AutoAdminLogon persistence: Sysmon EID 13 (RegistryEvent value-set) writing
+  value 1 to HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\AutoAdminLogon
+  via reg.exe. Observed in BlackMatter ransomware attacks to maintain access
+  after a safe mode reboot, enabling automatic privileged logon for further
+  encryption operations.
+tags: [eid13, blackmatter]
+mitre:
+  tactics: [credential-access, persistence]
+  techniques: [T1552.002]
+
+state:
+  computer:         gen.hostname(class=windows-server, domain=corp.local)
+  sysmon_pid:       gen.int(min=1000, max=4000)
+  sysmon_tid:       gen.int(min=1000, max=9999)
+  process_pid:      gen.int(min=1000, max=9999)
+  process_guid_raw: gen.uuid()
+  process_guid:     "{${ref.process_guid_raw}}"
+  event_record_id:  gen.int(min=5000, max=99999)
+  target_object:    "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\AutoAdminLogon"
+  details:          "1"
+  image:            "C:\\Windows\\system32\\reg.exe"
+
+steps:
+  - emit:
+      event_type: windows.wineventlog@v1
+      fields:
+        System:
+          Provider:
+            "@Name": Microsoft-Windows-Sysmon
+            "@Guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}"
+          EventID: 13
+          Version: 2
+          Level: 4
+          Task: 13
+          Opcode: 0
+          Keywords: "0x8000000000000000"
+          TimeCreated:
+            "@SystemTime": gen.timestamp(format=wineventlog)
+          EventRecordID: ref.event_record_id
+          Correlation: {}
+          Execution:
+            "@ProcessID": ref.sysmon_pid
+            "@ThreadID": ref.sysmon_tid
+          Channel: Microsoft-Windows-Sysmon/Operational
+          Computer: ref.computer
+          Security:
+            "@UserID": S-1-5-18
+        EventData:
+          Data:
+            - "@Name": RuleName
+              "#text": "-"
+            - "@Name": EventType
+              "#text": SetValue
+            - "@Name": UtcTime
+              "#text": gen.timestamp(format=sysmon)
+            - "@Name": ProcessGuid
+              "#text": ref.process_guid
+            - "@Name": ProcessId
+              "#text": ref.process_pid
+            - "@Name": Image
+              "#text": ref.image
+            - "@Name": TargetObject
+              "#text": ref.target_object
+            - "@Name": Details
+              "#text": ref.details

--- a/scenarios/windows/sysmon/registry/auto-admin-logon-set.yaml
+++ b/scenarios/windows/sysmon/registry/auto-admin-logon-set.yaml
@@ -5,7 +5,7 @@ description: |
   via reg.exe. Observed in BlackMatter ransomware attacks to maintain access
   after a safe mode reboot, enabling automatic privileged logon for further
   encryption operations.
-tags: [eid13, blackmatter]
+tags: [eid13]
 mitre:
   tactics: [credential-access, persistence]
   techniques: [T1552.002]

--- a/scenarios/windows/sysmon/registry/auto-admin-logon-set.yaml
+++ b/scenarios/windows/sysmon/registry/auto-admin-logon-set.yaml
@@ -20,7 +20,7 @@ state:
   event_record_id:  gen.int(min=5000, max=99999)
   target_object:    "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\AutoAdminLogon"
   details:          "1"
-  image:            "C:\\Windows\\system32\\reg.exe"
+  image:            "C:\\Windows\\System32\\reg.exe"
 
 steps:
   - emit:


### PR DESCRIPTION
- Add `auto-admin-logon-registry-entry.yaml` job: Validates ESCU detection for registry changes enabling AutoAdminLogon (credential-access, persistence).
- Add `auto-admin-logon-set.yaml` scenario: Models Sysmon EID 13 for BlackMatter ransomware technique modifying Winlogon\AutoAdminLogon via reg.exe.
- Include benign W32Time SecureTimeConfidence update scenario to ensure detection specificity.