### PR TITLE
Scenarios and validation job for DSQuery Domain Discovery (T1482)

### DIFF
--- a/jobs/splunk/windows/sysmon/process-create/dsquery-domain-discovery.yaml
+++ b/jobs/splunk/windows/sysmon/process-create/dsquery-domain-discovery.yaml
@@ -1,0 +1,28 @@
+type: job
+description: |
+  Validates the ESCU "DSQuery Domain Discovery" detection (T1482).
+
+  One attack workload emits a Sysmon EID 1 for `dsquery.exe` with
+  `(objectClass=trustedDomain)` in its command line — the canonical
+  domain trust enumeration shape. A second workload emits the parent
+  `cmd.exe` shell whose CommandLine bundles the same dsquery
+  invocation; this is a false-positive control because the SPL
+  filter ANDs `process_name=dsquery.exe` with `process=*trustedDomain*`,
+  so the cmd-side process must not fire the alert.
+
+mitre:
+  tactics: [discovery]
+  techniques: [T1482]
+
+workloads:
+  - scenario: scenarios/windows/sysmon/process-create/dsquery-trusteddomain-discovery
+    detection:
+      expected: alert
+      attack: "DSQuery Domain Discovery"
+      mitre:
+        tactics: [discovery]
+        techniques: [T1482]
+
+  - scenario: scenarios/windows/sysmon/process-create/cmd-launches-dsquery-trusteddomain
+    detection:
+      expected: none

--- a/scenarios/windows/sysmon/process-create/cmd-launches-dsquery-trusteddomain.yaml
+++ b/scenarios/windows/sysmon/process-create/cmd-launches-dsquery-trusteddomain.yaml
@@ -1,0 +1,106 @@
+type: scenario
+description: |
+  Sysmon EID 1 (Process Create) for the parent `cmd.exe` shell that wraps a
+  dsquery domain trust query. The cmd's CommandLine carries the literal
+  `trustedDomain` token because it bundles the dsquery invocation, but
+  `process_name` is `cmd.exe`, not `dsquery.exe`. This is the false-positive
+  control for dsquery-domain-discovery detections that AND together
+  `process_name=dsquery.exe` with `process=*trustedDomain*` — a detector
+  that keys only on the command-line substring would mistakenly fire on
+  this shell process.
+tags: [eid1]
+
+state:
+  computer:            gen.hostname(class=windows-workstation, domain=corp.local)
+  sysmon_pid:          gen.int(min=1000, max=4000)
+  sysmon_tid:          gen.int(min=1000, max=9999)
+  process_guid_raw:    gen.uuid()
+  process_guid:        "{${ref.process_guid_raw}}"
+  process_id:          gen.int(min=1000, max=9999)
+  parent_guid_raw:     gen.uuid()
+  parent_process_guid: "{${ref.parent_guid_raw}}"
+  parent_process_id:   gen.int(min=1000, max=9999)
+  logon_guid_raw:      gen.uuid()
+  logon_guid:          "{${ref.logon_guid_raw}}"
+  event_record_id:     gen.int(min=5000, max=99999)
+  username:            gen.username()
+  user_domain:         CORP
+  user:                "${ref.user_domain}\\${ref.username}"
+  image:               C:\Windows\System32\cmd.exe
+  original_file_name:  Cmd.Exe
+  command_line:        '"C:\Windows\system32\cmd.exe" /c "dsquery * -filter "(objectClass=trustedDomain)" -attr *" '
+  current_directory:   "C:\\Users\\${ref.username}\\AppData\\Local\\Temp\\"
+  parent_image:        C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
+  parent_command_line: '"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" '
+
+steps:
+  - emit:
+      event_type: windows.wineventlog@v1
+      fields:
+        System:
+          Provider:
+            "@Name": Microsoft-Windows-Sysmon
+            "@Guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}"
+          EventID: 1
+          Version: 5
+          Level: 4
+          Task: 1
+          Opcode: 0
+          Keywords: "0x8000000000000000"
+          TimeCreated:
+            "@SystemTime": gen.timestamp(format=wineventlog)
+          EventRecordID: ref.event_record_id
+          Correlation: {}
+          Execution:
+            "@ProcessID": ref.sysmon_pid
+            "@ThreadID": ref.sysmon_tid
+          Channel: Microsoft-Windows-Sysmon/Operational
+          Computer: ref.computer
+          Security:
+            "@UserID": S-1-5-18
+        EventData:
+          Data:
+            - "@Name": RuleName
+              "#text": "-"
+            - "@Name": UtcTime
+              "#text": gen.timestamp(format=sysmon)
+            - "@Name": ProcessGuid
+              "#text": ref.process_guid
+            - "@Name": ProcessId
+              "#text": ref.process_id
+            - "@Name": Image
+              "#text": ref.image
+            - "@Name": FileVersion
+              "#text": 10.0.14393.0
+            - "@Name": Description
+              "#text": Windows Command Processor
+            - "@Name": Product
+              "#text": "Microsoft® Windows® Operating System"
+            - "@Name": Company
+              "#text": Microsoft Corporation
+            - "@Name": OriginalFileName
+              "#text": ref.original_file_name
+            - "@Name": CommandLine
+              "#text": ref.command_line
+            - "@Name": CurrentDirectory
+              "#text": ref.current_directory
+            - "@Name": User
+              "#text": ref.user
+            - "@Name": LogonGuid
+              "#text": ref.logon_guid
+            - "@Name": LogonId
+              "#text": "0x13a7da"
+            - "@Name": TerminalSessionId
+              "#text": 2
+            - "@Name": IntegrityLevel
+              "#text": High
+            - "@Name": Hashes
+              "#text": "MD5=F4F684066175B77E0C3A000549D2922C,SHA256=935C1861DF1F4018D698E8B65ABFA02D7E9037D8F68CA3C2065B6CA165D44AD2,IMPHASH=3062ED732D4B25D1C64F084DAC97D37A"
+            - "@Name": ParentProcessGuid
+              "#text": ref.parent_process_guid
+            - "@Name": ParentProcessId
+              "#text": ref.parent_process_id
+            - "@Name": ParentImage
+              "#text": ref.parent_image
+            - "@Name": ParentCommandLine
+              "#text": ref.parent_command_line

--- a/scenarios/windows/sysmon/process-create/dsquery-trusteddomain-discovery.yaml
+++ b/scenarios/windows/sysmon/process-create/dsquery-trusteddomain-discovery.yaml
@@ -1,0 +1,109 @@
+type: scenario
+description: |
+  Sysmon EID 1 (Process Create) recording a `dsquery.exe` invocation that
+  enumerates Active Directory trust relationships via the
+  `(objectClass=trustedDomain)` LDAP filter — the canonical domain trust
+  discovery probe (MITRE T1482). The process is launched from `cmd.exe`,
+  which is the typical hands-on-keyboard or atomic-test shape; the
+  command line itself carries the `trustedDomain` token detection logic
+  filters on. This is the attack-positive shape for dsquery-based domain
+  trust enumeration.
+tags: [eid1]
+mitre:
+  tactics: [discovery]
+  techniques: [T1482]
+
+state:
+  computer:            gen.hostname(class=windows-workstation, domain=corp.local)
+  sysmon_pid:          gen.int(min=1000, max=4000)
+  sysmon_tid:          gen.int(min=1000, max=9999)
+  process_guid_raw:    gen.uuid()
+  process_guid:        "{${ref.process_guid_raw}}"
+  process_id:          gen.int(min=1000, max=9999)
+  parent_guid_raw:     gen.uuid()
+  parent_process_guid: "{${ref.parent_guid_raw}}"
+  parent_process_id:   gen.int(min=1000, max=9999)
+  logon_guid_raw:      gen.uuid()
+  logon_guid:          "{${ref.logon_guid_raw}}"
+  event_record_id:     gen.int(min=5000, max=99999)
+  username:            gen.username()
+  user_domain:         CORP
+  user:                "${ref.user_domain}\\${ref.username}"
+  image:               C:\Windows\System32\dsquery.exe
+  original_file_name:  dsquery.exe
+  command_line:        'dsquery  * -filter "(objectClass=trustedDomain)" -attr * '
+  current_directory:   "C:\\Users\\${ref.username}\\AppData\\Local\\Temp\\"
+  parent_image:        C:\Windows\System32\cmd.exe
+  parent_command_line: '"C:\Windows\system32\cmd.exe" /c "dsquery * -filter "(objectClass=trustedDomain)" -attr *" '
+
+steps:
+  - emit:
+      event_type: windows.wineventlog@v1
+      fields:
+        System:
+          Provider:
+            "@Name": Microsoft-Windows-Sysmon
+            "@Guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}"
+          EventID: 1
+          Version: 5
+          Level: 4
+          Task: 1
+          Opcode: 0
+          Keywords: "0x8000000000000000"
+          TimeCreated:
+            "@SystemTime": gen.timestamp(format=wineventlog)
+          EventRecordID: ref.event_record_id
+          Correlation: {}
+          Execution:
+            "@ProcessID": ref.sysmon_pid
+            "@ThreadID": ref.sysmon_tid
+          Channel: Microsoft-Windows-Sysmon/Operational
+          Computer: ref.computer
+          Security:
+            "@UserID": S-1-5-18
+        EventData:
+          Data:
+            - "@Name": RuleName
+              "#text": "-"
+            - "@Name": UtcTime
+              "#text": gen.timestamp(format=sysmon)
+            - "@Name": ProcessGuid
+              "#text": ref.process_guid
+            - "@Name": ProcessId
+              "#text": ref.process_id
+            - "@Name": Image
+              "#text": ref.image
+            - "@Name": FileVersion
+              "#text": 10.0.14393.0
+            - "@Name": Description
+              "#text": Microsoft AD DS/LDS query command line utility
+            - "@Name": Product
+              "#text": "Microsoft® Windows® Operating System"
+            - "@Name": Company
+              "#text": Microsoft Corporation
+            - "@Name": OriginalFileName
+              "#text": ref.original_file_name
+            - "@Name": CommandLine
+              "#text": ref.command_line
+            - "@Name": CurrentDirectory
+              "#text": ref.current_directory
+            - "@Name": User
+              "#text": ref.user
+            - "@Name": LogonGuid
+              "#text": ref.logon_guid
+            - "@Name": LogonId
+              "#text": "0x13a7da"
+            - "@Name": TerminalSessionId
+              "#text": 2
+            - "@Name": IntegrityLevel
+              "#text": High
+            - "@Name": Hashes
+              "#text": "MD5=0F173F934D6FED9B140763559F70DF65,SHA256=3201CC050F642D0B3AD759EDCF57287082200831A258FBC2F17B4C96B53A28A7,IMPHASH=D442E29184F60B794AD2B7508D569FC3"
+            - "@Name": ParentProcessGuid
+              "#text": ref.parent_process_guid
+            - "@Name": ParentProcessId
+              "#text": ref.parent_process_id
+            - "@Name": ParentImage
+              "#text": ref.parent_image
+            - "@Name": ParentCommandLine
+              "#text": ref.parent_command_line


### PR DESCRIPTION


- Add `dsquery-trusteddomain-discovery.yaml` scenario: Models Sysmon EID 1 for `dsquery.exe` enumerating trusted domains using LDAP filters (attack-positive).
- Add `cmd-launches-dsquery-trusteddomain.yaml` scenario: Simulates a benign `cmd.exe` process wrapping `dsquery` invocation for false-positive control.
- Add `dsquery-domain-discovery.yaml` job: Validates detection accuracy by distinguishing between attack and benign workloads for domain discovery via DSQuery.