### PR TITLE
Unified defaults for scenarios / jobs

### DIFF
--- a/jobs/splunk/windows/sysmon/dns-query/3cx-supply-chain-attack-network-indicators.yaml
+++ b/jobs/splunk/windows/sysmon/dns-query/3cx-supply-chain-attack-network-indicators.yaml
@@ -18,8 +18,12 @@ state:
   # Lifted to job-scope so detection.correlation can reference them. The
   # scenario keeps its own defaults; bindings below project these values
   # into the workload.
-  query_name: "www.3cx.com"
-  computer:   gen.hostname(class=windows-workstation, domain=corp.local)
+  query_name:         "www.3cx.com"
+  domain_short:       CORP
+  domain_tld:         local
+  domain_short_lower: fn.lower(ref.domain_short)
+  domain_fqdn:        "${ref.domain_short_lower}.${ref.domain_tld}"
+  computer:           gen.hostname(class=windows-workstation, domain=ref.domain_fqdn)
 
 workloads:
   - scenario: scenarios/windows/sysmon/dns-query/3cx-ioc-dns-query

--- a/jobs/splunk/windows/wineventlog/logon/detect-password-spray-attempts.yaml
+++ b/jobs/splunk/windows/wineventlog/logon/detect-password-spray-attempts.yaml
@@ -17,9 +17,13 @@ mitre:
   techniques: ["T1110.003"]
 
 state:
-  src_host: gen.ipv4()
+  src_host:           gen.ipv4()
+  domain_short:       CORP
+  domain_tld:         local
+  domain_short_lower: fn.lower(ref.domain_short)
+  domain_fqdn:        "${ref.domain_short_lower}.${ref.domain_tld}"
   # make sure host is reliably unique as it's used as the main source of uniqueness in the detection correlation
-  host:     gen.hostname(class=windows-workstation)
+  host:               gen.hostname(class=windows-workstation)
 
 pools:
   - id: ntlm-failure-modes
@@ -37,7 +41,9 @@ workloads:
     bindings:
       src_host:       ref.src_host
       workstation:    ref.host
-      computer:       "${ref.host}.corp.local"
+      domain_short:   ref.domain_short
+      domain_tld:     ref.domain_tld
+      computer:       "${ref.host}.${ref.domain_fqdn}"
       # One pool draw per iteration. Per-field bindings would each
       # issue their own Get() and scramble fields across rows.
       auth_row:       pool.ntlm-failure-modes

--- a/scenarios/aws/cloudtrail/delete-trail.yaml
+++ b/scenarios/aws/cloudtrail/delete-trail.yaml
@@ -10,6 +10,7 @@ state:
   account_id:  "000000000000"
   actor:       gen.aws_identity(type=IAMUser, accountId=ref.account_id)
   source_ip:   gen.ipv4()
+  user_agent:  "aws-cli/2.15.30 Python/3.11.8 Darwin/23.4.0 source/x86_64 prompt/off tracemill/1.0"
   tls_version: "TLSv1.3"
   tls_cipher:  TLS_AES_128_GCM_SHA256
   trail_name:  production-trail
@@ -28,7 +29,7 @@ steps:
         eventCategory:      Management
         awsRegion:          ref.aws_region
         sourceIPAddress:    ref.source_ip
-        userAgent:          tracemill/1.0
+        userAgent:          ref.user_agent
         requestID:          gen.uuid()
         requestParameters:
           name: ref.trail_name

--- a/scenarios/aws/iam/create-access-key.yaml
+++ b/scenarios/aws/iam/create-access-key.yaml
@@ -10,6 +10,7 @@ state:
   account_id:    "000000000000"
   actor:         gen.aws_identity(type=IAMUser, userName=attacker-user, accountId=ref.account_id)
   source_ip:     gen.ipv4()
+  user_agent:    "Boto3/1.34.51 Python/3.11.8 Linux/5.15.0-101-generic Botocore/1.34.51 tracemill/1.0"
   tls_version:   "TLSv1.3"
   tls_cipher:    TLS_AES_128_GCM_SHA256
   new_key:       gen.aws_access_key(userName=target-admin)
@@ -27,7 +28,7 @@ steps:
         eventCategory:      Management
         awsRegion:          ref.aws_region
         sourceIPAddress:    ref.source_ip
-        userAgent:          tracemill/1.0
+        userAgent:          ref.user_agent
         requestID:          gen.uuid()
         requestParameters:
           userName: ref.new_key.userName

--- a/scenarios/aws/iam/update-login-profile.yaml
+++ b/scenarios/aws/iam/update-login-profile.yaml
@@ -10,6 +10,7 @@ state:
   account_id:    "000000000000"
   actor:         gen.aws_identity(type=IAMUser, userName=attacker-user, accountId=ref.account_id)
   source_ip:     gen.ipv4()
+  user_agent:    "aws-cli/2.15.30 Python/3.11.8 Linux/5.15.0-101-generic source/x86_64 prompt/off tracemill/1.0"
   target_user:   target-admin
 
 steps:
@@ -25,7 +26,7 @@ steps:
         eventCategory:      Management
         awsRegion:          ref.aws_region
         sourceIPAddress:    ref.source_ip
-        userAgent:          tracemill/1.0
+        userAgent:          ref.user_agent
         requestID:          gen.uuid()
         requestParameters:
           userName:              ref.target_user

--- a/scenarios/aws/s3/put-bucket-lifecycle.yaml
+++ b/scenarios/aws/s3/put-bucket-lifecycle.yaml
@@ -11,6 +11,7 @@ state:
   account_id:    "000000000000"
   actor:         gen.aws_identity(type=IAMUser, accountId=ref.account_id)
   source_ip:     gen.ipv4()
+  user_agent:    "aws-cli/2.15.30 Python/3.11.8 Darwin/23.4.0 source/x86_64 prompt/off tracemill/1.0"
   tls_version:   "TLSv1.3"
   tls_cipher:    TLS_AES_128_GCM_SHA256
   bucket_name:   target-cloudtrail-logs
@@ -30,7 +31,7 @@ steps:
         eventCategory:      Management
         awsRegion:          ref.aws_region
         sourceIPAddress:    ref.source_ip
-        userAgent:          tracemill/1.0
+        userAgent:          ref.user_agent
         requestID:          gen.uuid()
         requestParameters:
           lifecycle: ""

--- a/scenarios/windows/sysmon/dns-query/3cx-ioc-dns-query.yaml
+++ b/scenarios/windows/sysmon/dns-query/3cx-ioc-dns-query.yaml
@@ -13,7 +13,11 @@ mitre:
   techniques: [T1195.002]
 
 state:
-  computer:        gen.hostname(class=windows-workstation, domain=corp.local)
+  domain_short:       CORP
+  domain_tld:         local
+  domain_short_lower: fn.lower(ref.domain_short)
+  domain_fqdn:        "${ref.domain_short_lower}.${ref.domain_tld}"
+  computer:        gen.hostname(class=windows-workstation, domain=ref.domain_fqdn)
   sysmon_pid:      gen.int(min=1000, max=4000)
   sysmon_tid:      gen.int(min=1000, max=9999)
   process_pid:     gen.int(min=1000, max=9999)

--- a/scenarios/windows/sysmon/dns-query/3cx-ioc-dns-query.yaml
+++ b/scenarios/windows/sysmon/dns-query/3cx-ioc-dns-query.yaml
@@ -24,7 +24,7 @@ state:
   process_guid_raw: gen.uuid()
   process_guid:    "{${ref.process_guid_raw}}"
   user:            gen.username()
-  user_qualified:  "CORP\\${ref.user}"
+  user_qualified:  "${ref.domain_short}\\${ref.user}"
   image:           "C:\\Program Files\\Mozilla Firefox\\firefox.exe"
   query_name:      "www.3cx.com"
   query_status:    "0"

--- a/scenarios/windows/sysmon/process-access/lsass-access-routine.yaml
+++ b/scenarios/windows/sysmon/process-access/lsass-access-routine.yaml
@@ -9,7 +9,11 @@ description: |
 tags: [eid10]
 
 state:
-  computer:            gen.hostname(class=windows-workstation, domain=corp.local)
+  domain_short:       CORP
+  domain_tld:         local
+  domain_short_lower: fn.lower(ref.domain_short)
+  domain_fqdn:        "${ref.domain_short_lower}.${ref.domain_tld}"
+  computer:            gen.hostname(class=windows-workstation, domain=ref.domain_fqdn)
   sysmon_pid:          gen.int(min=1000, max=4000)
   sysmon_tid:          gen.int(min=1000, max=9999)
   target_guid_raw:     gen.uuid()

--- a/scenarios/windows/sysmon/process-access/lsass-dump-comsvcs.yaml
+++ b/scenarios/windows/sysmon/process-access/lsass-dump-comsvcs.yaml
@@ -11,7 +11,11 @@ mitre:
   techniques: [T1003.001]
 
 state:
-  computer:            gen.hostname(class=windows-workstation, domain=corp.local)
+  domain_short:       CORP
+  domain_tld:         local
+  domain_short_lower: fn.lower(ref.domain_short)
+  domain_fqdn:        "${ref.domain_short_lower}.${ref.domain_tld}"
+  computer:            gen.hostname(class=windows-workstation, domain=ref.domain_fqdn)
   sysmon_pid:          gen.int(min=1000, max=4000)
   sysmon_tid:          gen.int(min=1000, max=9999)
   source_guid_raw:     gen.uuid()

--- a/scenarios/windows/sysmon/process-access/lsass-dump-procdump.yaml
+++ b/scenarios/windows/sysmon/process-access/lsass-dump-procdump.yaml
@@ -9,7 +9,11 @@ mitre:
   techniques: [T1003.001]
 
 state:
-  computer:            gen.hostname(class=windows-workstation, domain=corp.local)
+  domain_short:       CORP
+  domain_tld:         local
+  domain_short_lower: fn.lower(ref.domain_short)
+  domain_fqdn:        "${ref.domain_short_lower}.${ref.domain_tld}"
+  computer:            gen.hostname(class=windows-workstation, domain=ref.domain_fqdn)
   sysmon_pid:          gen.int(min=1000, max=4000)
   sysmon_tid:          gen.int(min=1000, max=9999)
   source_guid_raw:     gen.uuid()

--- a/scenarios/windows/sysmon/process-create/cmd-launches-dsquery-trusteddomain.yaml
+++ b/scenarios/windows/sysmon/process-create/cmd-launches-dsquery-trusteddomain.yaml
@@ -11,7 +11,11 @@ description: |
 tags: [eid1]
 
 state:
-  computer:            gen.hostname(class=windows-workstation, domain=corp.local)
+  domain_short:       CORP
+  domain_tld:         local
+  domain_short_lower: fn.lower(ref.domain_short)
+  domain_fqdn:        "${ref.domain_short_lower}.${ref.domain_tld}"
+  computer:            gen.hostname(class=windows-workstation, domain=ref.domain_fqdn)
   sysmon_pid:          gen.int(min=1000, max=4000)
   sysmon_tid:          gen.int(min=1000, max=9999)
   process_guid_raw:    gen.uuid()
@@ -24,7 +28,7 @@ state:
   logon_guid:          "{${ref.logon_guid_raw}}"
   event_record_id:     gen.int(min=5000, max=99999)
   username:            gen.username()
-  user_domain:         CORP
+  user_domain:         ref.domain_short
   user:                "${ref.user_domain}\\${ref.username}"
   image:               C:\Windows\System32\cmd.exe
   original_file_name:  Cmd.Exe

--- a/scenarios/windows/sysmon/process-create/defender-add-ext-exclusion.yaml
+++ b/scenarios/windows/sysmon/process-create/defender-add-ext-exclusion.yaml
@@ -12,7 +12,11 @@ mitre:
   techniques: [T1562.001]
 
 state:
-  computer:            gen.hostname(class=windows-workstation, domain=corp.local)
+  domain_short:       CORP
+  domain_tld:         local
+  domain_short_lower: fn.lower(ref.domain_short)
+  domain_fqdn:        "${ref.domain_short_lower}.${ref.domain_tld}"
+  computer:            gen.hostname(class=windows-workstation, domain=ref.domain_fqdn)
   sysmon_pid:          gen.int(min=1000, max=4000)
   sysmon_tid:          gen.int(min=1000, max=9999)
   process_guid_raw:    gen.uuid()
@@ -25,7 +29,7 @@ state:
   logon_guid:          "{${ref.logon_guid_raw}}"
   event_record_id:     gen.int(min=5000, max=99999)
   username:            gen.username()
-  user_domain:         CORP
+  user_domain:         ref.domain_short
   user:                "${ref.user_domain}\\${ref.username}"
   exclusion_extension: "\".exe\""
   image:               C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe

--- a/scenarios/windows/sysmon/process-create/defender-add-folder-exclusion.yaml
+++ b/scenarios/windows/sysmon/process-create/defender-add-folder-exclusion.yaml
@@ -11,7 +11,11 @@ mitre:
   techniques: [T1562.001]
 
 state:
-  computer:            gen.hostname(class=windows-workstation, domain=corp.local)
+  domain_short:       CORP
+  domain_tld:         local
+  domain_short_lower: fn.lower(ref.domain_short)
+  domain_fqdn:        "${ref.domain_short_lower}.${ref.domain_tld}"
+  computer:            gen.hostname(class=windows-workstation, domain=ref.domain_fqdn)
   sysmon_pid:          gen.int(min=1000, max=4000)
   sysmon_tid:          gen.int(min=1000, max=9999)
   process_guid_raw:    gen.uuid()
@@ -24,7 +28,7 @@ state:
   logon_guid:          "{${ref.logon_guid_raw}}"
   event_record_id:     gen.int(min=5000, max=99999)
   username:            gen.username()
-  user_domain:         CORP
+  user_domain:         ref.domain_short
   user:                "${ref.user_domain}\\${ref.username}"
   exclusion_path:      C:\Temp
   image:               C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe

--- a/scenarios/windows/sysmon/process-create/defender-add-process-exclusion.yaml
+++ b/scenarios/windows/sysmon/process-create/defender-add-process-exclusion.yaml
@@ -11,7 +11,11 @@ mitre:
   techniques: [T1562.001]
 
 state:
-  computer:            gen.hostname(class=windows-workstation, domain=corp.local)
+  domain_short:       CORP
+  domain_tld:         local
+  domain_short_lower: fn.lower(ref.domain_short)
+  domain_fqdn:        "${ref.domain_short_lower}.${ref.domain_tld}"
+  computer:            gen.hostname(class=windows-workstation, domain=ref.domain_fqdn)
   sysmon_pid:          gen.int(min=1000, max=4000)
   sysmon_tid:          gen.int(min=1000, max=9999)
   process_guid_raw:    gen.uuid()
@@ -24,7 +28,7 @@ state:
   logon_guid:          "{${ref.logon_guid_raw}}"
   event_record_id:     gen.int(min=5000, max=99999)
   username:            gen.username()
-  user_domain:         CORP
+  user_domain:         ref.domain_short
   user:                "${ref.user_domain}\\${ref.username}"
   exclusion_process:   C:\Temp\evil.msi
   image:               C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe

--- a/scenarios/windows/sysmon/process-create/defender-set-folder-exclusion.yaml
+++ b/scenarios/windows/sysmon/process-create/defender-set-folder-exclusion.yaml
@@ -12,7 +12,11 @@ mitre:
   techniques: [T1562.001]
 
 state:
-  computer:            gen.hostname(class=windows-workstation, domain=corp.local)
+  domain_short:       CORP
+  domain_tld:         local
+  domain_short_lower: fn.lower(ref.domain_short)
+  domain_fqdn:        "${ref.domain_short_lower}.${ref.domain_tld}"
+  computer:            gen.hostname(class=windows-workstation, domain=ref.domain_fqdn)
   sysmon_pid:          gen.int(min=1000, max=4000)
   sysmon_tid:          gen.int(min=1000, max=9999)
   process_guid_raw:    gen.uuid()
@@ -25,7 +29,7 @@ state:
   logon_guid:          "{${ref.logon_guid_raw}}"
   event_record_id:     gen.int(min=5000, max=99999)
   username:            gen.username()
-  user_domain:         CORP
+  user_domain:         ref.domain_short
   user:                "${ref.user_domain}\\${ref.username}"
   exclusion_path:      "C:\\"
   image:               C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe

--- a/scenarios/windows/sysmon/process-create/dsquery-trusteddomain-discovery.yaml
+++ b/scenarios/windows/sysmon/process-create/dsquery-trusteddomain-discovery.yaml
@@ -14,7 +14,11 @@ mitre:
   techniques: [T1482]
 
 state:
-  computer:            gen.hostname(class=windows-workstation, domain=corp.local)
+  domain_short:       CORP
+  domain_tld:         local
+  domain_short_lower: fn.lower(ref.domain_short)
+  domain_fqdn:        "${ref.domain_short_lower}.${ref.domain_tld}"
+  computer:            gen.hostname(class=windows-workstation, domain=ref.domain_fqdn)
   sysmon_pid:          gen.int(min=1000, max=4000)
   sysmon_tid:          gen.int(min=1000, max=9999)
   process_guid_raw:    gen.uuid()
@@ -27,7 +31,7 @@ state:
   logon_guid:          "{${ref.logon_guid_raw}}"
   event_record_id:     gen.int(min=5000, max=99999)
   username:            gen.username()
-  user_domain:         CORP
+  user_domain:         ref.domain_short
   user:                "${ref.user_domain}\\${ref.username}"
   image:               C:\Windows\System32\dsquery.exe
   original_file_name:  dsquery.exe

--- a/scenarios/windows/sysmon/process-create/multi-letter-process.yaml
+++ b/scenarios/windows/sysmon/process-create/multi-letter-process.yaml
@@ -13,7 +13,11 @@ description: |
 tags: [eid1]
 
 state:
-  computer:            gen.hostname(class=windows-workstation, domain=corp.local)
+  domain_short:       CORP
+  domain_tld:         local
+  domain_short_lower: fn.lower(ref.domain_short)
+  domain_fqdn:        "${ref.domain_short_lower}.${ref.domain_tld}"
+  computer:            gen.hostname(class=windows-workstation, domain=ref.domain_fqdn)
   sysmon_pid:          gen.int(min=1000, max=4000)
   sysmon_tid:          gen.int(min=1000, max=9999)
   process_guid_raw:    gen.uuid()
@@ -26,7 +30,7 @@ state:
   logon_guid:          "{${ref.logon_guid_raw}}"
   event_record_id:     gen.int(min=5000, max=99999)
   username:            gen.username()
-  user_domain:         CORP
+  user_domain:         ref.domain_short
   user:                "${ref.user_domain}\\${ref.username}"
   # Parameterised process identity. process_basename must be a
   # multi-character executable name to keep this workload a valid

--- a/scenarios/windows/sysmon/process-create/netsh-allow-file-and-printer-sharing.yaml
+++ b/scenarios/windows/sysmon/process-create/netsh-allow-file-and-printer-sharing.yaml
@@ -12,7 +12,11 @@ mitre:
   techniques: [T1562.004]
 
 state:
-  computer:            gen.hostname(class=windows-workstation, domain=corp.local)
+  domain_short:       CORP
+  domain_tld:         local
+  domain_short_lower: fn.lower(ref.domain_short)
+  domain_fqdn:        "${ref.domain_short_lower}.${ref.domain_tld}"
+  computer:            gen.hostname(class=windows-workstation, domain=ref.domain_fqdn)
   sysmon_pid:          gen.int(min=1000, max=4000)
   sysmon_tid:          gen.int(min=1000, max=9999)
   process_guid_raw:    gen.uuid()
@@ -25,7 +29,7 @@ state:
   logon_guid:          "{${ref.logon_guid_raw}}"
   event_record_id:     gen.int(min=5000, max=99999)
   username:            gen.username()
-  user_domain:         CORP
+  user_domain:         ref.domain_short
   user:                "${ref.user_domain}\\${ref.username}"
   image:               C:\Windows\System32\netsh.exe
   original_file_name:  netsh.exe

--- a/scenarios/windows/sysmon/process-create/netsh-allow-net-discovery.yaml
+++ b/scenarios/windows/sysmon/process-create/netsh-allow-net-discovery.yaml
@@ -12,7 +12,11 @@ mitre:
   techniques: [T1562.004]
 
 state:
-  computer:            gen.hostname(class=windows-workstation, domain=corp.local)
+  domain_short:       CORP
+  domain_tld:         local
+  domain_short_lower: fn.lower(ref.domain_short)
+  domain_fqdn:        "${ref.domain_short_lower}.${ref.domain_tld}"
+  computer:            gen.hostname(class=windows-workstation, domain=ref.domain_fqdn)
   sysmon_pid:          gen.int(min=1000, max=4000)
   sysmon_tid:          gen.int(min=1000, max=9999)
   process_guid_raw:    gen.uuid()
@@ -25,7 +29,7 @@ state:
   logon_guid:          "{${ref.logon_guid_raw}}"
   event_record_id:     gen.int(min=5000, max=99999)
   username:            gen.username()
-  user_domain:         CORP
+  user_domain:         ref.domain_short
   user:                "${ref.user_domain}\\${ref.username}"
   image:               C:\Windows\System32\netsh.exe
   original_file_name:  netsh.exe

--- a/scenarios/windows/sysmon/process-create/netsh-firewall-show-rules.yaml
+++ b/scenarios/windows/sysmon/process-create/netsh-firewall-show-rules.yaml
@@ -8,7 +8,11 @@ description: |
 tags: [eid1]
 
 state:
-  computer:            gen.hostname(class=windows-workstation, domain=corp.local)
+  domain_short:       CORP
+  domain_tld:         local
+  domain_short_lower: fn.lower(ref.domain_short)
+  domain_fqdn:        "${ref.domain_short_lower}.${ref.domain_tld}"
+  computer:            gen.hostname(class=windows-workstation, domain=ref.domain_fqdn)
   sysmon_pid:          gen.int(min=1000, max=4000)
   sysmon_tid:          gen.int(min=1000, max=9999)
   process_guid_raw:    gen.uuid()
@@ -21,7 +25,7 @@ state:
   logon_guid:          "{${ref.logon_guid_raw}}"
   event_record_id:     gen.int(min=5000, max=99999)
   username:            gen.username()
-  user_domain:         CORP
+  user_domain:         ref.domain_short
   user:                "${ref.user_domain}\\${ref.username}"
   image:               C:\Windows\System32\netsh.exe
   original_file_name:  netsh.exe

--- a/scenarios/windows/sysmon/process-create/single-letter-exe.yaml
+++ b/scenarios/windows/sysmon/process-create/single-letter-exe.yaml
@@ -18,7 +18,11 @@ mitre:
   techniques: [T1204.002]
 
 state:
-  computer:            gen.hostname(class=windows-workstation, domain=corp.local)
+  domain_short:       CORP
+  domain_tld:         local
+  domain_short_lower: fn.lower(ref.domain_short)
+  domain_fqdn:        "${ref.domain_short_lower}.${ref.domain_tld}"
+  computer:            gen.hostname(class=windows-workstation, domain=ref.domain_fqdn)
   sysmon_pid:          gen.int(min=1000, max=4000)
   sysmon_tid:          gen.int(min=1000, max=9999)
   process_guid_raw:    gen.uuid()
@@ -31,7 +35,7 @@ state:
   logon_guid:          "{${ref.logon_guid_raw}}"
   event_record_id:     gen.int(min=5000, max=99999)
   username:            gen.username()
-  user_domain:         CORP
+  user_domain:         ref.domain_short
   user:                "${ref.user_domain}\\${ref.username}"
   # Single-character executable basename. Default keeps the scenario
   # runnable standalone; job bindings overriding this should draw from

--- a/scenarios/windows/sysmon/registry/active-setup-stubpath.yaml
+++ b/scenarios/windows/sysmon/registry/active-setup-stubpath.yaml
@@ -13,7 +13,11 @@ mitre:
   techniques: [T1547.014]
 
 state:
-  computer:           gen.hostname(class=windows-workstation, domain=corp.local)
+  domain_short:       CORP
+  domain_tld:         local
+  domain_short_lower: fn.lower(ref.domain_short)
+  domain_fqdn:        "${ref.domain_short_lower}.${ref.domain_tld}"
+  computer:           gen.hostname(class=windows-workstation, domain=ref.domain_fqdn)
   sysmon_pid:         gen.int(min=1000, max=4000)
   sysmon_tid:         gen.int(min=1000, max=9999)
   process_pid:        gen.int(min=1000, max=9999)

--- a/scenarios/windows/sysmon/registry/auto-admin-logon-set.yaml
+++ b/scenarios/windows/sysmon/registry/auto-admin-logon-set.yaml
@@ -11,7 +11,11 @@ mitre:
   techniques: [T1552.002]
 
 state:
-  computer:         gen.hostname(class=windows-server, domain=corp.local)
+  domain_short:       CORP
+  domain_tld:         local
+  domain_short_lower: fn.lower(ref.domain_short)
+  domain_fqdn:        "${ref.domain_short_lower}.${ref.domain_tld}"
+  computer:         gen.hostname(class=windows-server, domain=ref.domain_fqdn)
   sysmon_pid:       gen.int(min=1000, max=4000)
   sysmon_tid:       gen.int(min=1000, max=9999)
   process_pid:      gen.int(min=1000, max=9999)

--- a/scenarios/windows/sysmon/registry/consent-prompt-admin-suppress.yaml
+++ b/scenarios/windows/sysmon/registry/consent-prompt-admin-suppress.yaml
@@ -12,7 +12,11 @@ mitre:
   techniques: [T1548.002]
 
 state:
-  computer:         gen.hostname(class=windows-workstation, domain=corp.local)
+  domain_short:       CORP
+  domain_tld:         local
+  domain_short_lower: fn.lower(ref.domain_short)
+  domain_fqdn:        "${ref.domain_short_lower}.${ref.domain_tld}"
+  computer:         gen.hostname(class=windows-workstation, domain=ref.domain_fqdn)
   sysmon_pid:       gen.int(min=1000, max=4000)
   sysmon_tid:       gen.int(min=1000, max=9999)
   process_pid:      gen.int(min=400, max=9999)

--- a/scenarios/windows/sysmon/registry/firewall-allow-inbound-rule.yaml
+++ b/scenarios/windows/sysmon/registry/firewall-allow-inbound-rule.yaml
@@ -11,7 +11,11 @@ mitre:
   techniques: [T1021.001]
 
 state:
-  computer:         gen.hostname(class=windows-workstation, domain=corp.local)
+  domain_short:       CORP
+  domain_tld:         local
+  domain_short_lower: fn.lower(ref.domain_short)
+  domain_fqdn:        "${ref.domain_short_lower}.${ref.domain_tld}"
+  computer:         gen.hostname(class=windows-workstation, domain=ref.domain_fqdn)
   sysmon_pid:       gen.int(min=1000, max=4000)
   sysmon_tid:       gen.int(min=1000, max=9999)
   process_pid:      gen.int(min=1000, max=9999)

--- a/scenarios/windows/sysmon/registry/w32time-config-set.yaml
+++ b/scenarios/windows/sysmon/registry/w32time-config-set.yaml
@@ -11,7 +11,11 @@ description: |
 tags: [eid13]
 
 state:
-  computer:         gen.hostname(class=windows-workstation, domain=corp.local)
+  domain_short:       CORP
+  domain_tld:         local
+  domain_short_lower: fn.lower(ref.domain_short)
+  domain_fqdn:        "${ref.domain_short_lower}.${ref.domain_tld}"
+  computer:         gen.hostname(class=windows-workstation, domain=ref.domain_fqdn)
   sysmon_pid:       gen.int(min=1000, max=4000)
   sysmon_tid:       gen.int(min=1000, max=9999)
   process_pid:      gen.int(min=400, max=900)

--- a/scenarios/windows/wineventlog/account-management/local-group-member-added.yaml
+++ b/scenarios/windows/wineventlog/account-management/local-group-member-added.yaml
@@ -8,9 +8,12 @@ description: |
 tags: [eid4720, eid4732]
 
 state:
-  computer:              gen.hostname(class=windows-server, domain=corp.local)
   domain_short:          CORP
-  domain_dn:             "DC=corp,DC=local"
+  domain_tld:            local
+  domain_short_lower:    fn.lower(ref.domain_short)
+  domain_fqdn:           "${ref.domain_short_lower}.${ref.domain_tld}"
+  domain_dn:             "DC=${ref.domain_short_lower},DC=${ref.domain_tld}"
+  computer:              gen.hostname(class=windows-server, domain=ref.domain_fqdn)
   new_user:              gen.username()
   new_user_rid:          gen.int(min=1100, max=9999)
   new_user_sid:          "S-1-5-21-111222333-444555666-777888999-${ref.new_user_rid}"

--- a/scenarios/windows/wineventlog/account-management/new-local-admin.yaml
+++ b/scenarios/windows/wineventlog/account-management/new-local-admin.yaml
@@ -10,9 +10,12 @@ mitre:
   techniques: [T1136.001]
 
 state:
-  computer:              gen.hostname(class=windows-server, domain=corp.local)
   domain_short:          CORP
-  domain_dn:             "DC=corp,DC=local"
+  domain_tld:            local
+  domain_short_lower:    fn.lower(ref.domain_short)
+  domain_fqdn:           "${ref.domain_short_lower}.${ref.domain_tld}"
+  domain_dn:             "DC=${ref.domain_short_lower},DC=${ref.domain_tld}"
+  computer:              gen.hostname(class=windows-server, domain=ref.domain_fqdn)
   new_user:              gen.username()
   new_user_dn:           "CN=${ref.new_user},CN=Users,${ref.domain_dn}"
   new_user_rid:          gen.int(min=1100, max=9999)

--- a/scenarios/windows/wineventlog/account-management/user-account-created.yaml
+++ b/scenarios/windows/wineventlog/account-management/user-account-created.yaml
@@ -7,8 +7,11 @@ description: |
 tags: [eid4720]
 
 state:
-  computer:          gen.hostname(class=windows-server, domain=corp.local)
   domain_short:      CORP
+  domain_tld:        local
+  domain_short_lower: fn.lower(ref.domain_short)
+  domain_fqdn:       "${ref.domain_short_lower}.${ref.domain_tld}"
+  computer:          gen.hostname(class=windows-server, domain=ref.domain_fqdn)
   new_user:          gen.username()
   new_user_rid:      gen.int(min=1100, max=9999)
   new_user_sid:      "S-1-5-21-111222333-444555666-777888999-${ref.new_user_rid}"

--- a/scenarios/windows/wineventlog/logon/failed-login-from-src.yaml
+++ b/scenarios/windows/wineventlog/logon/failed-login-from-src.yaml
@@ -17,9 +17,12 @@ mitre:
   techniques: ["T1110.001", "T1110.003"]
 
 state:
-  computer:        gen.hostname(class=windows-server, domain=corp.local)
-  domain_short:    CORP
-  src_host:        gen.ipv4()
+  domain_short:       CORP
+  domain_tld:         local
+  domain_short_lower: fn.lower(ref.domain_short)
+  domain_fqdn:        "${ref.domain_short_lower}.${ref.domain_tld}"
+  computer:           gen.hostname(class=windows-server, domain=ref.domain_fqdn)
+  src_host:           gen.ipv4()
   target_user:     gen.username()
   workstation:     gen.hostname(class=windows-workstation)
   src_port:        gen.int(min=49152, max=65535)


### PR DESCRIPTION
- Replace hardcoded "corp.local" domain with dynamically generated `domain_fqdn` using `domain_short` and `domain_tld`.
- Introduce `domain_short_lower` for consistent lowercased domain references.
- Update computer, user, and domain fields across all impacted scenarios and jobs for consistency and reusability.