### PR TITLE
Add scenarios and validation job for AWS AMI attribute modification (T1537)

### DIFF
--- a/jobs/splunk/aws/ec2/aws-ami-attribute-modification-for-exfiltration.yaml
+++ b/jobs/splunk/aws/ec2/aws-ami-attribute-modification-for-exfiltration.yaml
@@ -2,32 +2,34 @@ type: job
 description: |
   Validation job for AWS AMI Attribute Modification for Exfiltration.
 
-  Exercises both attack variants the SPL covers — sharing an AMI with a
-  specific external account and making it publicly accessible (group=all)
-  — from a single actor/source so the SPL's stats-by tuple
-  (signature, dest, user, user_agent, src, vendor_account, vendor_region,
-  vendor_product) collapses to a small group.
+  Exercises two AMI attribute modification paths: sharing an AMI with a
+  specific external account and making it publicly accessible (group=all).
+  Both actions use the same actor and source context so related events can
+  be grouped together.
 
 mitre:
   tactics: [exfiltration]
   techniques: [T1537]
 
 state:
-  account_id:  "111111111111"
-  aws_region:  us-west-2
-  source_ip:   gen.ipv4()
-  user_agent:  AWS Internal
-  actor:       gen.aws_identity(type=AssumedRole, accountId=ref.account_id)
+  account_id:        "111111111111"
+  shared_account_id: "222222222222"
+  aws_region:        us-east-1
+  source_ip:         gen.ipv4()
+  user_agent:        "AWS Internal tracemill/1.0"
+  actor:             gen.aws_identity(type=AssumedRole, accountId=ref.account_id)
 
 workloads:
   - scenario: scenarios/aws/ec2/share-image-with-account
     bindings:
-      account_id: ref.account_id
-      aws_region: ref.aws_region
-      source_ip:  ref.source_ip
-      user_agent: ref.user_agent
-      actor:      ref.actor
+      account_id:        ref.account_id
+      aws_region:        ref.aws_region
+      source_ip:         ref.source_ip
+      user_agent:        ref.user_agent
+      actor:             ref.actor
+      shared_account_id: ref.shared_account_id
     detection:
+      attack: AWS AMI Attribute Modification for Exfiltration
       expected: alert
 
   - scenario: scenarios/aws/ec2/share-image-publicly
@@ -38,4 +40,5 @@ workloads:
       user_agent: ref.user_agent
       actor:      ref.actor
     detection:
+      attack: AWS AMI Attribute Modification for Exfiltration
       expected: alert

--- a/jobs/splunk/aws/ec2/aws-ami-attribute-modification-for-exfiltration.yaml
+++ b/jobs/splunk/aws/ec2/aws-ami-attribute-modification-for-exfiltration.yaml
@@ -1,10 +1,41 @@
 type: job
 description: |
   Validation job for AWS AMI Attribute Modification for Exfiltration.
+
+  Exercises both attack variants the SPL covers — sharing an AMI with a
+  specific external account and making it publicly accessible (group=all)
+  — from a single actor/source so the SPL's stats-by tuple
+  (signature, dest, user, user_agent, src, vendor_account, vendor_region,
+  vendor_product) collapses to a small group.
+
+mitre:
+  tactics: [exfiltration]
+  techniques: [T1537]
+
+state:
+  account_id:  "111111111111"
+  aws_region:  us-west-2
+  source_ip:   gen.ipv4()
+  user_agent:  AWS Internal
+  actor:       gen.aws_identity(type=AssumedRole, accountId=ref.account_id)
+
 workloads:
   - scenario: scenarios/aws/ec2/share-image-with-account
+    bindings:
+      account_id: ref.account_id
+      aws_region: ref.aws_region
+      source_ip:  ref.source_ip
+      user_agent: ref.user_agent
+      actor:      ref.actor
     detection:
       expected: alert
+
   - scenario: scenarios/aws/ec2/share-image-publicly
+    bindings:
+      account_id: ref.account_id
+      aws_region: ref.aws_region
+      source_ip:  ref.source_ip
+      user_agent: ref.user_agent
+      actor:      ref.actor
     detection:
       expected: alert

--- a/jobs/splunk/aws/ec2/aws-ami-attribute-modification-for-exfiltration.yaml
+++ b/jobs/splunk/aws/ec2/aws-ami-attribute-modification-for-exfiltration.yaml
@@ -1,0 +1,10 @@
+type: job
+description: |
+  Validation job for AWS AMI Attribute Modification for Exfiltration.
+workloads:
+  - scenario: scenarios/aws/ec2/share-image-with-account
+    detection:
+      expected: alert
+  - scenario: scenarios/aws/ec2/share-image-publicly
+    detection:
+      expected: alert

--- a/scenarios/aws/ec2/share-image-publicly.yaml
+++ b/scenarios/aws/ec2/share-image-publicly.yaml
@@ -1,0 +1,46 @@
+type: scenario
+description: |
+  Exfiltration: actor sets an EC2 AMI's launchPermission to group=all,
+  making it publicly accessible to every AWS account.
+mitre:
+  tactics: [exfiltration]
+  techniques: [T1537]
+
+state:
+  aws_region:  us-west-2
+  account_id:  "111111111111"
+  ami_id:      ami-0a2011b9052129617
+  actor:       gen.aws_identity(type=AssumedRole, accountId=ref.account_id)
+  source_ip:   gen.ipv4()
+  request_id:  gen.uuid()
+
+steps:
+  - emit:
+      event_type: aws.cloudtrail@v1
+      fields:
+        eventVersion:                 "1.08"
+        eventTime:                    gen.timestamp()
+        eventID:                      gen.uuid()
+        eventSource:                  ec2.amazonaws.com
+        eventName:                    ModifyImageAttribute
+        eventType:                    AwsApiCall
+        eventCategory:                Management
+        awsRegion:                    ref.aws_region
+        sourceIPAddress:              ref.source_ip
+        userAgent:                    AWS Internal
+        requestID:                    ref.request_id
+        requestParameters:
+          imageId:       ref.ami_id
+          launchPermission:
+            add:
+              items:
+                - group: all
+          attributeType: launchPermission
+        responseElements:
+          requestId: ref.request_id
+          _return:   true
+        readOnly:                     false
+        managementEvent:              true
+        recipientAccountId:           ref.account_id
+        userIdentity:                 ref.actor
+        sessionCredentialFromConsole: "true"

--- a/scenarios/aws/ec2/share-image-publicly.yaml
+++ b/scenarios/aws/ec2/share-image-publicly.yaml
@@ -9,10 +9,10 @@ mitre:
 state:
   aws_region:  us-west-2
   account_id:  "111111111111"
-  ami_id:      ami-0a2011b9052129617
+  ami_id:      ami-0deadbeef00000002
   actor:       gen.aws_identity(type=AssumedRole, accountId=ref.account_id)
   source_ip:   gen.ipv4()
-  user_agent:  AWS Internal
+  user_agent:  "AWS Internal tracemill/1.0"
   request_id:  gen.uuid()
 
 steps:

--- a/scenarios/aws/ec2/share-image-publicly.yaml
+++ b/scenarios/aws/ec2/share-image-publicly.yaml
@@ -12,6 +12,7 @@ state:
   ami_id:      ami-0a2011b9052129617
   actor:       gen.aws_identity(type=AssumedRole, accountId=ref.account_id)
   source_ip:   gen.ipv4()
+  user_agent:  AWS Internal
   request_id:  gen.uuid()
 
 steps:
@@ -27,7 +28,7 @@ steps:
         eventCategory:                Management
         awsRegion:                    ref.aws_region
         sourceIPAddress:              ref.source_ip
-        userAgent:                    AWS Internal
+        userAgent:                    ref.user_agent
         requestID:                    ref.request_id
         requestParameters:
           imageId:       ref.ami_id

--- a/scenarios/aws/ec2/share-image-publicly.yaml
+++ b/scenarios/aws/ec2/share-image-publicly.yaml
@@ -7,7 +7,7 @@ mitre:
   techniques: [T1537]
 
 state:
-  aws_region:  us-west-2
+  aws_region:  us-east-1
   account_id:  "111111111111"
   ami_id:      ami-0deadbeef00000002
   actor:       gen.aws_identity(type=AssumedRole, accountId=ref.account_id)

--- a/scenarios/aws/ec2/share-image-with-account.yaml
+++ b/scenarios/aws/ec2/share-image-with-account.yaml
@@ -1,0 +1,47 @@
+type: scenario
+description: |
+  Exfiltration: actor shares an EC2 AMI with an external AWS account by
+  modifying its launchPermission attribute to add a target accountId.
+mitre:
+  tactics: [exfiltration]
+  techniques: [T1537]
+
+state:
+  aws_region:        us-west-2
+  account_id:        "111111111111"
+  shared_account_id: "140429656527"
+  ami_id:            ami-06dac31db29508566
+  actor:             gen.aws_identity(type=AssumedRole, accountId=ref.account_id)
+  source_ip:         gen.ipv4()
+  request_id:        gen.uuid()
+
+steps:
+  - emit:
+      event_type: aws.cloudtrail@v1
+      fields:
+        eventVersion:                 "1.08"
+        eventTime:                    gen.timestamp()
+        eventID:                      gen.uuid()
+        eventSource:                  ec2.amazonaws.com
+        eventName:                    ModifyImageAttribute
+        eventType:                    AwsApiCall
+        eventCategory:                Management
+        awsRegion:                    ref.aws_region
+        sourceIPAddress:              ref.source_ip
+        userAgent:                    AWS Internal
+        requestID:                    ref.request_id
+        requestParameters:
+          imageId:       ref.ami_id
+          launchPermission:
+            add:
+              items:
+                - userId: ref.shared_account_id
+          attributeType: launchPermission
+        responseElements:
+          requestId: ref.request_id
+          _return:   true
+        readOnly:                     false
+        managementEvent:              true
+        recipientAccountId:           ref.account_id
+        userIdentity:                 ref.actor
+        sessionCredentialFromConsole: "true"

--- a/scenarios/aws/ec2/share-image-with-account.yaml
+++ b/scenarios/aws/ec2/share-image-with-account.yaml
@@ -13,6 +13,7 @@ state:
   ami_id:            ami-06dac31db29508566
   actor:             gen.aws_identity(type=AssumedRole, accountId=ref.account_id)
   source_ip:         gen.ipv4()
+  user_agent:        AWS Internal
   request_id:        gen.uuid()
 
 steps:
@@ -28,7 +29,7 @@ steps:
         eventCategory:                Management
         awsRegion:                    ref.aws_region
         sourceIPAddress:              ref.source_ip
-        userAgent:                    AWS Internal
+        userAgent:                    ref.user_agent
         requestID:                    ref.request_id
         requestParameters:
           imageId:       ref.ami_id

--- a/scenarios/aws/ec2/share-image-with-account.yaml
+++ b/scenarios/aws/ec2/share-image-with-account.yaml
@@ -7,7 +7,7 @@ mitre:
   techniques: [T1537]
 
 state:
-  aws_region:        us-west-2
+  aws_region:        us-east-1
   account_id:        "111111111111"
   shared_account_id: "222222222222"
   ami_id:            ami-0deadbeef00000001

--- a/scenarios/aws/ec2/share-image-with-account.yaml
+++ b/scenarios/aws/ec2/share-image-with-account.yaml
@@ -9,11 +9,11 @@ mitre:
 state:
   aws_region:        us-west-2
   account_id:        "111111111111"
-  shared_account_id: "140429656527"
-  ami_id:            ami-06dac31db29508566
+  shared_account_id: "222222222222"
+  ami_id:            ami-0deadbeef00000001
   actor:             gen.aws_identity(type=AssumedRole, accountId=ref.account_id)
   source_ip:         gen.ipv4()
-  user_agent:        AWS Internal
+  user_agent:        "AWS Internal tracemill/1.0"
   request_id:        gen.uuid()
 
 steps:


### PR DESCRIPTION


- Add `aws-ami-attribute-modification-for-exfiltration.yaml` job to validate detection of unauthorized AWS AMI launchPermission modifications (alert mode).
- Add `share-image-with-account.yaml` scenario for sharing AMI with a specific account.
- Add `share-image-publicly.yaml` scenario for making an AMI publicly accessible.
- Classify scenarios under exfiltration tactic (T1537).