### PR TITLE
Add scenarios for AWS AMI sharing via Organization and  OU (T1537)

### DIFF
--- a/jobs/splunk/aws/ec2/aws-ami-attribute-modification-for-exfiltration.yaml
+++ b/jobs/splunk/aws/ec2/aws-ami-attribute-modification-for-exfiltration.yaml
@@ -8,8 +8,6 @@ description: |
     2. Make publicly accessible (group=all).
     3. Share with every account in an AWS Organization (organizationArn).
     4. Share with every account under an Organizational Unit (organizationalUnitArn).
-  See docs/aws-ami-attribute-modification-detection-gaps.md for the
-  detection-gap context behind workloads 3 and 4.
 
 mitre:
   tactics: [exfiltration]

--- a/jobs/splunk/aws/ec2/aws-ami-attribute-modification-for-exfiltration.yaml
+++ b/jobs/splunk/aws/ec2/aws-ami-attribute-modification-for-exfiltration.yaml
@@ -2,10 +2,17 @@ type: job
 description: |
   Validation job for AWS AMI Attribute Modification for Exfiltration.
 
-  Exercises two AMI attribute modification paths: sharing an AMI with a
-  specific external account and making it publicly accessible (group=all).
-  Both actions use the same actor and source context so related events can
-  be grouped together.
+  Exercises four AMI attribute modification paths under one actor and
+  source context so related events can be grouped together:
+    1. Share with a specific external account (userId).
+    2. Make publicly accessible (group=all).
+    3. Share with every account in an AWS Organization (organizationArn) -
+       gap variant; semantically attack-positive but the upstream SPL
+       does not currently inspect this field.
+    4. Share with every account under an Organizational Unit
+       (organizationalUnitArn) - same gap.
+  See docs/aws-ami-attribute-modification-detection-gaps.md for the
+  detection-gap context behind workloads 3 and 4.
 
 mitre:
   tactics: [exfiltration]
@@ -14,6 +21,10 @@ mitre:
 state:
   account_id:        "111111111111"
   shared_account_id: "222222222222"
+  shared_org_id:     "o-exfilorg01"
+  shared_ou_id:      "ou-1234-exfilou01"
+  shared_org_arn:    "arn:aws:organizations::${ref.account_id}:organization/${ref.shared_org_id}"
+  shared_ou_arn:     "arn:aws:organizations::${ref.account_id}:ou/${ref.shared_org_id}/${ref.shared_ou_id}"
   aws_region:        us-east-1
   source_ip:         gen.ipv4()
   user_agent:        "AWS Internal tracemill/1.0"
@@ -39,6 +50,30 @@ workloads:
       source_ip:  ref.source_ip
       user_agent: ref.user_agent
       actor:      ref.actor
+    detection:
+      attack: AWS AMI Attribute Modification for Exfiltration
+      expected: alert
+
+  - scenario: scenarios/aws/ec2/share-image-with-organization
+    bindings:
+      account_id:     ref.account_id
+      aws_region:     ref.aws_region
+      source_ip:      ref.source_ip
+      user_agent:     ref.user_agent
+      actor:          ref.actor
+      shared_org_arn: ref.shared_org_arn
+    detection:
+      attack: AWS AMI Attribute Modification for Exfiltration
+      expected: alert
+
+  - scenario: scenarios/aws/ec2/share-image-with-ou
+    bindings:
+      account_id:    ref.account_id
+      aws_region:    ref.aws_region
+      source_ip:     ref.source_ip
+      user_agent:    ref.user_agent
+      actor:         ref.actor
+      shared_ou_arn: ref.shared_ou_arn
     detection:
       attack: AWS AMI Attribute Modification for Exfiltration
       expected: alert

--- a/jobs/splunk/aws/ec2/aws-ami-attribute-modification-for-exfiltration.yaml
+++ b/jobs/splunk/aws/ec2/aws-ami-attribute-modification-for-exfiltration.yaml
@@ -6,11 +6,8 @@ description: |
   source context so related events can be grouped together:
     1. Share with a specific external account (userId).
     2. Make publicly accessible (group=all).
-    3. Share with every account in an AWS Organization (organizationArn) -
-       gap variant; semantically attack-positive but the upstream SPL
-       does not currently inspect this field.
-    4. Share with every account under an Organizational Unit
-       (organizationalUnitArn) - same gap.
+    3. Share with every account in an AWS Organization (organizationArn).
+    4. Share with every account under an Organizational Unit (organizationalUnitArn).
   See docs/aws-ami-attribute-modification-detection-gaps.md for the
   detection-gap context behind workloads 3 and 4.
 

--- a/scenarios/aws/ec2/share-image-with-organization.yaml
+++ b/scenarios/aws/ec2/share-image-with-organization.yaml
@@ -1,0 +1,51 @@
+type: scenario
+description: |
+  Exfiltration: actor shares an EC2 AMI with every account in an AWS
+  Organization by passing OrganizationArn to ModifyImageAttribute. The
+  request does not populate launchPermission.add.items, so detections
+  that only inspect that array (e.g. the upstream
+  aws_ami_attribute_modification_for_exfiltration filter) miss this
+  variant.
+mitre:
+  tactics: [exfiltration]
+  techniques: [T1537]
+
+state:
+  aws_region:        us-east-1
+  account_id:        "111111111111"
+  shared_org_id:     "o-exfilorg01"
+  shared_org_arn:    "arn:aws:organizations::${ref.account_id}:organization/${ref.shared_org_id}"
+  ami_id:            ami-0deadbeef00000003
+  actor:             gen.aws_identity(type=AssumedRole, accountId=ref.account_id)
+  source_ip:         gen.ipv4()
+  user_agent:        "AWS Internal tracemill/1.0"
+  request_id:        gen.uuid()
+
+steps:
+  - emit:
+      event_type: aws.cloudtrail@v1
+      fields:
+        eventVersion:                 "1.08"
+        eventTime:                    gen.timestamp()
+        eventID:                      gen.uuid()
+        eventSource:                  ec2.amazonaws.com
+        eventName:                    ModifyImageAttribute
+        eventType:                    AwsApiCall
+        eventCategory:                Management
+        awsRegion:                    ref.aws_region
+        sourceIPAddress:              ref.source_ip
+        userAgent:                    ref.user_agent
+        requestID:                    ref.request_id
+        requestParameters:
+          imageId:         ref.ami_id
+          attributeType:   launchPermission
+          organizationArn:
+            - ref.shared_org_arn
+        responseElements:
+          requestId: ref.request_id
+          _return:   true
+        readOnly:                     false
+        managementEvent:              true
+        recipientAccountId:           ref.account_id
+        userIdentity:                 ref.actor
+        sessionCredentialFromConsole: "true"

--- a/scenarios/aws/ec2/share-image-with-organization.yaml
+++ b/scenarios/aws/ec2/share-image-with-organization.yaml
@@ -1,11 +1,10 @@
 type: scenario
 description: |
   Exfiltration: actor shares an EC2 AMI with every account in an AWS
-  Organization by passing OrganizationArn to ModifyImageAttribute. The
-  request does not populate launchPermission.add.items, so detections
-  that only inspect that array (e.g. the upstream
-  aws_ami_attribute_modification_for_exfiltration filter) miss this
-  variant.
+  Organization by adding an organizationArn item to
+  ModifyImageAttribute's launchPermission. CloudTrail records the share
+  as an organizationArn item alongside the userId / group items emitted
+  by the more common per-account / public-share variants.
 mitre:
   tactics: [exfiltration]
   techniques: [T1537]
@@ -37,10 +36,12 @@ steps:
         userAgent:                    ref.user_agent
         requestID:                    ref.request_id
         requestParameters:
-          imageId:         ref.ami_id
-          attributeType:   launchPermission
-          organizationArn:
-            - ref.shared_org_arn
+          imageId:       ref.ami_id
+          launchPermission:
+            add:
+              items:
+                - organizationArn: ref.shared_org_arn
+          attributeType: launchPermission
         responseElements:
           requestId: ref.request_id
           _return:   true

--- a/scenarios/aws/ec2/share-image-with-ou.yaml
+++ b/scenarios/aws/ec2/share-image-with-ou.yaml
@@ -1,10 +1,10 @@
 type: scenario
 description: |
   Exfiltration: actor shares an EC2 AMI with every account under an
-  Organizational Unit by passing OrganizationalUnitArn to
-  ModifyImageAttribute. The request does not populate
-  launchPermission.add.items, so detections that only inspect that
-  array miss this variant.
+  Organizational Unit by adding an organizationalUnitArn item to
+  ModifyImageAttribute's launchPermission. CloudTrail records the
+  share as an organizationalUnitArn item alongside the userId / group
+  items emitted by the more common per-account / public-share variants.
 mitre:
   tactics: [exfiltration]
   techniques: [T1537]
@@ -37,10 +37,12 @@ steps:
         userAgent:                    ref.user_agent
         requestID:                    ref.request_id
         requestParameters:
-          imageId:         ref.ami_id
-          attributeType:   launchPermission
-          organizationalUnitArn:
-            - ref.shared_ou_arn
+          imageId:       ref.ami_id
+          launchPermission:
+            add:
+              items:
+                - organizationalUnitArn: ref.shared_ou_arn
+          attributeType: launchPermission
         responseElements:
           requestId: ref.request_id
           _return:   true

--- a/scenarios/aws/ec2/share-image-with-ou.yaml
+++ b/scenarios/aws/ec2/share-image-with-ou.yaml
@@ -1,0 +1,51 @@
+type: scenario
+description: |
+  Exfiltration: actor shares an EC2 AMI with every account under an
+  Organizational Unit by passing OrganizationalUnitArn to
+  ModifyImageAttribute. The request does not populate
+  launchPermission.add.items, so detections that only inspect that
+  array miss this variant.
+mitre:
+  tactics: [exfiltration]
+  techniques: [T1537]
+
+state:
+  aws_region:        us-east-1
+  account_id:        "111111111111"
+  shared_org_id:     "o-exfilorg01"
+  shared_ou_id:      "ou-1234-exfilou01"
+  shared_ou_arn:     "arn:aws:organizations::${ref.account_id}:ou/${ref.shared_org_id}/${ref.shared_ou_id}"
+  ami_id:            ami-0deadbeef00000004
+  actor:             gen.aws_identity(type=AssumedRole, accountId=ref.account_id)
+  source_ip:         gen.ipv4()
+  user_agent:        "AWS Internal tracemill/1.0"
+  request_id:        gen.uuid()
+
+steps:
+  - emit:
+      event_type: aws.cloudtrail@v1
+      fields:
+        eventVersion:                 "1.08"
+        eventTime:                    gen.timestamp()
+        eventID:                      gen.uuid()
+        eventSource:                  ec2.amazonaws.com
+        eventName:                    ModifyImageAttribute
+        eventType:                    AwsApiCall
+        eventCategory:                Management
+        awsRegion:                    ref.aws_region
+        sourceIPAddress:              ref.source_ip
+        userAgent:                    ref.user_agent
+        requestID:                    ref.request_id
+        requestParameters:
+          imageId:         ref.ami_id
+          attributeType:   launchPermission
+          organizationalUnitArn:
+            - ref.shared_ou_arn
+        responseElements:
+          requestId: ref.request_id
+          _return:   true
+        readOnly:                     false
+        managementEvent:              true
+        recipientAccountId:           ref.account_id
+        userIdentity:                 ref.actor
+        sessionCredentialFromConsole: "true"


### PR DESCRIPTION

- Add `share-image-with-organization.yaml` scenario for AMI sharing using `organizationArn`.
- Add `share-image-with-ou.yaml` scenario for AMI sharing using `organizationalUnitArn`.
- Update `aws-ami-attribute-modification-for-exfiltration.yaml` job to include new scenarios and highlight detection gaps in certain fields.