### PR TITLE
AWS Bedrock Delete GuardRails detection (T1562.008)

### DIFF
--- a/jobs/splunk/aws/bedrock/aws-bedrock-delete-guardrails.yaml
+++ b/jobs/splunk/aws/bedrock/aws-bedrock-delete-guardrails.yaml
@@ -1,6 +1,6 @@
 type: job
 description: |
-  Validation job for AWS Bedrock Delete GuardRails.
+  Validation job for AWS Bedrock Delete Guardrails.
 
 mitre:
   tactics: [defense-evasion]
@@ -24,5 +24,5 @@ workloads:
       actor:          ref.actor
       guardrail_uuid: ref.guardrail_uuid
     detection:
-      attack: AWS Bedrock Delete GuardRails
+      attack: AWS Bedrock Delete Guardrails
       expected: alert

--- a/jobs/splunk/aws/bedrock/aws-bedrock-delete-guardrails.yaml
+++ b/jobs/splunk/aws/bedrock/aws-bedrock-delete-guardrails.yaml
@@ -1,0 +1,28 @@
+type: job
+description: |
+  Validation job for AWS Bedrock Delete GuardRails.
+
+mitre:
+  tactics: [defense-evasion]
+  techniques: [T1562.008]
+
+state:
+  account_id:     "111111111111"
+  aws_region:     us-east-1
+  source_ip:      gen.ipv4()
+  user_agent:     "aws-cli/2.15.30 Python/3.11.8 Darwin/23.4.0 source/x86_64 prompt/off tracemill/1.0"
+  actor:          gen.aws_identity(type=AssumedRole, accountId=ref.account_id)
+  guardrail_uuid: gen.uuid()
+
+workloads:
+  - scenario: scenarios/aws/bedrock/delete-guardrail
+    bindings:
+      account_id:     ref.account_id
+      aws_region:     ref.aws_region
+      source_ip:      ref.source_ip
+      user_agent:     ref.user_agent
+      actor:          ref.actor
+      guardrail_uuid: ref.guardrail_uuid
+    detection:
+      attack: AWS Bedrock Delete GuardRails
+      expected: alert

--- a/scenarios/aws/bedrock/delete-guardrail.yaml
+++ b/scenarios/aws/bedrock/delete-guardrail.yaml
@@ -1,0 +1,46 @@
+type: scenario
+description: |
+  Defense evasion: actor deletes an AWS Bedrock guardrail, removing safety
+  controls that prevent harmful, biased, or jailbroken model outputs.
+mitre:
+  tactics: [defense-evasion]
+  techniques: [T1562.008]
+
+state:
+  aws_region:    us-east-1
+  account_id:    "000000000000"
+  actor:         gen.aws_identity(type=AssumedRole, accountId=ref.account_id)
+  source_ip:     gen.ipv4()
+  user_agent:    "aws-cli/2.15.30 Python/3.11.8 Darwin/23.4.0 source/x86_64 prompt/off tracemill/1.0"
+  tls_version:   "TLSv1.3"
+  tls_cipher:    TLS_AES_128_GCM_SHA256
+  guardrail_uuid: gen.uuid()
+  guardrail_id:  fn.prefix(ref.guardrail_uuid, n=8)
+
+steps:
+  - emit:
+      event_type: aws.cloudtrail@v1
+      fields:
+        eventVersion:       "1.09"
+        eventTime:          gen.timestamp()
+        eventID:            gen.uuid()
+        eventSource:        bedrock.amazonaws.com
+        eventName:          DeleteGuardrail
+        eventType:          AwsApiCall
+        eventCategory:      Management
+        awsRegion:          ref.aws_region
+        sourceIPAddress:    ref.source_ip
+        userAgent:          ref.user_agent
+        requestID:          gen.uuid()
+        requestParameters:
+          guardrailIdentifier: ref.guardrail_id
+        responseElements:   null
+        readOnly:           false
+        managementEvent:    true
+        recipientAccountId: ref.account_id
+        userIdentity:       ref.actor
+        tlsDetails:
+          tlsVersion:               ref.tls_version
+          cipherSuite:              ref.tls_cipher
+          clientProvidedHostHeader: "bedrock.${ref.aws_region}.amazonaws.com"
+        sessionCredentialFromConsole: "true"


### PR DESCRIPTION
- Add `aws-bedrock-delete-guardrails.yaml` job to validate detection of AWS Bedrock guardrail deletion attempts.
- Add `delete-guardrail.yaml` scenario modeling defense evasion via guardrail removal, including CloudTrail event emission and bindings.
- Classify workloads under defense evasion tactic (T1562.008).