### PR TITLE
AWS Defense Evasion Impair Security Services detection (T1562.008)

### DIFF
--- a/jobs/splunk/aws/guardduty/aws-defense-evasion-impair-security-services.yaml
+++ b/jobs/splunk/aws/guardduty/aws-defense-evasion-impair-security-services.yaml
@@ -1,0 +1,83 @@
+type: job
+description: |
+  Validation job for AWS Defense Evasion Impair Security Services.
+  Exercises deletion API calls across GuardDuty (detector, IP set), WAF
+  Classic (rule, web ACL), and a CloudWatch Logs stream deletion that
+  the upstream detection's data_source list declares in scope but the
+  SPL clause set omits - included to confirm the detection gap.
+
+  A single attacker identity (`actor`) from a single `source_ip` makes
+  the five API calls against one `account_id` in one `aws_region`, so
+  the SPL's `stats by ... user user_agent src vendor_account vendor_region`
+  aggregation groups all calls into one fired-alert tuple per
+  signature - i.e. the holistic-run shape an analyst would see in
+  production.
+
+mitre:
+  tactics: [defense-evasion]
+  techniques: [T1562.008]
+
+state:
+  account_id:  "111111111111"
+  aws_region:  us-east-1
+  source_ip:   gen.ipv4()
+  actor:       gen.aws_identity(type=IAMUser, userName=attacker-cli, accountId=ref.account_id)
+  tls_version: "TLSv1.3"
+  tls_cipher:  TLS_AES_128_GCM_SHA256
+
+workloads:
+  - scenario: scenarios/aws/guardduty/delete-detector
+    bindings:
+      account_id:  ref.account_id
+      aws_region:  ref.aws_region
+      source_ip:   ref.source_ip
+      actor:       ref.actor
+      tls_version: ref.tls_version
+      tls_cipher:  ref.tls_cipher
+    detection:
+      attack: AWS Defense Evasion Impair Security Services
+      expected: alert
+  - scenario: scenarios/aws/guardduty/delete-ipset
+    bindings:
+      account_id:  ref.account_id
+      aws_region:  ref.aws_region
+      source_ip:   ref.source_ip
+      actor:       ref.actor
+      tls_version: ref.tls_version
+      tls_cipher:  ref.tls_cipher
+    detection:
+      attack: AWS Defense Evasion Impair Security Services
+      expected: alert
+  - scenario: scenarios/aws/waf/delete-rule
+    bindings:
+      account_id:  ref.account_id
+      aws_region:  ref.aws_region
+      source_ip:   ref.source_ip
+      actor:       ref.actor
+      tls_version: ref.tls_version
+      tls_cipher:  ref.tls_cipher
+    detection:
+      attack: AWS Defense Evasion Impair Security Services
+      expected: alert
+  - scenario: scenarios/aws/waf/delete-webacl
+    bindings:
+      account_id:  ref.account_id
+      aws_region:  ref.aws_region
+      source_ip:   ref.source_ip
+      actor:       ref.actor
+      tls_version: ref.tls_version
+      tls_cipher:  ref.tls_cipher
+    detection:
+      attack: AWS Defense Evasion Impair Security Services
+      expected: alert
+  - scenario: scenarios/aws/logs/delete-log-stream
+    bindings:
+      account_id:  ref.account_id
+      aws_region:  ref.aws_region
+      source_ip:   ref.source_ip
+      actor:       ref.actor
+      tls_version: ref.tls_version
+      tls_cipher:  ref.tls_cipher
+    detection:
+      attack: AWS Defense Evasion Impair Security Services
+      expected: alert

--- a/jobs/splunk/aws/guardduty/aws-defense-evasion-impair-security-services.yaml
+++ b/jobs/splunk/aws/guardduty/aws-defense-evasion-impair-security-services.yaml
@@ -1,17 +1,9 @@
 type: job
 description: |
   Validation job for AWS Defense Evasion Impair Security Services.
-  Exercises deletion API calls across GuardDuty (detector, IP set), WAF
-  Classic (rule, web ACL), and a CloudWatch Logs stream deletion that
-  the upstream detection's data_source list declares in scope but the
-  SPL clause set omits - included to confirm the detection gap.
-
-  A single attacker identity (`actor`) from a single `source_ip` makes
-  the five API calls against one `account_id` in one `aws_region`, so
-  the SPL's `stats by ... user user_agent src vendor_account vendor_region`
-  aggregation groups all calls into one fired-alert tuple per
-  signature - i.e. the holistic-run shape an analyst would see in
-  production.
+  Five deletion API calls (GuardDuty detector / IP set, WAF Classic
+  rule / web ACL, CloudWatch Logs stream) issued by one attacker
+  identity from one source IP against one account and region.
 
 mitre:
   tactics: [defense-evasion]

--- a/jobs/splunk/aws/guardduty/aws-defense-evasion-impair-security-services.yaml
+++ b/jobs/splunk/aws/guardduty/aws-defense-evasion-impair-security-services.yaml
@@ -6,8 +6,8 @@ description: |
   identity from one source IP against one account and region.
 
 mitre:
-  tactics: [defense-evasion]
-  techniques: [T1562.008]
+  tactics: [defense-evasion, impact]
+  techniques: [T1685, T1685.002, T1686.001, T1485]
 
 state:
   account_id:  "111111111111"

--- a/scenarios/aws/guardduty/delete-detector.yaml
+++ b/scenarios/aws/guardduty/delete-detector.yaml
@@ -1,0 +1,44 @@
+type: scenario
+description: |
+  Defense evasion: actor deletes a GuardDuty detector to disable threat
+  detection in the region.
+mitre:
+  tactics: [defense-evasion]
+  techniques: [T1562.008]
+
+state:
+  aws_region:  us-west-2
+  account_id:  "111111111111"
+  actor:       gen.aws_identity(type=IAMUser, userName=attacker-cli, accountId=ref.account_id)
+  source_ip:   gen.ipv4()
+  user_agent:  "aws-cli/2.7.3 Python/3.9.13 Darwin/21.5.0 source/x86_64 prompt/off command/guardduty.delete-detector"
+  tls_version: "TLSv1.3"
+  tls_cipher:  TLS_AES_128_GCM_SHA256
+  detector_id: gen.uuid()
+
+steps:
+  - emit:
+      event_type: aws.cloudtrail@v1
+      fields:
+        eventVersion:       "1.09"
+        eventTime:          gen.timestamp()
+        eventID:            gen.uuid()
+        eventSource:        guardduty.amazonaws.com
+        eventName:          DeleteDetector
+        eventType:          AwsApiCall
+        eventCategory:      Management
+        awsRegion:          ref.aws_region
+        sourceIPAddress:    ref.source_ip
+        userAgent:          ref.user_agent
+        requestID:          gen.uuid()
+        requestParameters:
+          detectorId: ref.detector_id
+        responseElements:   null
+        readOnly:           false
+        managementEvent:    true
+        recipientAccountId: ref.account_id
+        userIdentity:       ref.actor
+        tlsDetails:
+          tlsVersion:               ref.tls_version
+          cipherSuite:              ref.tls_cipher
+          clientProvidedHostHeader: "guardduty.${ref.aws_region}.amazonaws.com"

--- a/scenarios/aws/guardduty/delete-detector.yaml
+++ b/scenarios/aws/guardduty/delete-detector.yaml
@@ -4,7 +4,7 @@ description: |
   detection in the region.
 mitre:
   tactics: [defense-evasion]
-  techniques: [T1562.008]
+  techniques: [T1685]
 
 state:
   aws_region:  us-west-2

--- a/scenarios/aws/guardduty/delete-ipset.yaml
+++ b/scenarios/aws/guardduty/delete-ipset.yaml
@@ -4,7 +4,7 @@ description: |
   removing custom threat intelligence from the detector.
 mitre:
   tactics: [defense-evasion]
-  techniques: [T1562.008]
+  techniques: [T1685]
 
 state:
   aws_region:  us-west-2

--- a/scenarios/aws/guardduty/delete-ipset.yaml
+++ b/scenarios/aws/guardduty/delete-ipset.yaml
@@ -1,0 +1,46 @@
+type: scenario
+description: |
+  Defense evasion: actor deletes a GuardDuty trusted IP list (IP set),
+  removing custom threat intelligence from the detector.
+mitre:
+  tactics: [defense-evasion]
+  techniques: [T1562.008]
+
+state:
+  aws_region:  us-west-2
+  account_id:  "111111111111"
+  actor:       gen.aws_identity(type=IAMUser, userName=attacker-cli, accountId=ref.account_id)
+  source_ip:   gen.ipv4()
+  user_agent:  "aws-cli/2.0.62 Python/3.9.2 Darwin/21.5.0 source/x86_64 command/guardduty.delete-ip-set"
+  tls_version: "TLSv1.3"
+  tls_cipher:  TLS_AES_128_GCM_SHA256
+  detector_id: gen.uuid()
+  ipset_id:    gen.uuid()
+
+steps:
+  - emit:
+      event_type: aws.cloudtrail@v1
+      fields:
+        eventVersion:       "1.09"
+        eventTime:          gen.timestamp()
+        eventID:            gen.uuid()
+        eventSource:        guardduty.amazonaws.com
+        eventName:          DeleteIPSet
+        eventType:          AwsApiCall
+        eventCategory:      Management
+        awsRegion:          ref.aws_region
+        sourceIPAddress:    ref.source_ip
+        userAgent:          ref.user_agent
+        requestID:          gen.uuid()
+        requestParameters:
+          detectorId: ref.detector_id
+          ipSetId:    ref.ipset_id
+        responseElements:   null
+        readOnly:           false
+        managementEvent:    true
+        recipientAccountId: ref.account_id
+        userIdentity:       ref.actor
+        tlsDetails:
+          tlsVersion:               ref.tls_version
+          cipherSuite:              ref.tls_cipher
+          clientProvidedHostHeader: "guardduty.${ref.aws_region}.amazonaws.com"

--- a/scenarios/aws/logs/delete-log-stream.yaml
+++ b/scenarios/aws/logs/delete-log-stream.yaml
@@ -1,10 +1,7 @@
 type: scenario
 description: |
   Defense evasion / impact: actor deletes a CloudWatch Logs stream to
-  destroy archived log events and break audit trails feeding the SIEM.
-  Per the Splunk upstream detection's data_source list, DeleteLogStream
-  is in scope as a defense-evasion API call; the current SPL clause set
-  omits it (see findings under .cache/library-dev/findings/).
+  destroy archived log events and break audit trails.
 mitre:
   tactics: [defense-evasion, impact]
   techniques: [T1562.008, T1485]

--- a/scenarios/aws/logs/delete-log-stream.yaml
+++ b/scenarios/aws/logs/delete-log-stream.yaml
@@ -1,0 +1,49 @@
+type: scenario
+description: |
+  Defense evasion / impact: actor deletes a CloudWatch Logs stream to
+  destroy archived log events and break audit trails feeding the SIEM.
+  Per the Splunk upstream detection's data_source list, DeleteLogStream
+  is in scope as a defense-evasion API call; the current SPL clause set
+  omits it (see findings under .cache/library-dev/findings/).
+mitre:
+  tactics: [defense-evasion, impact]
+  techniques: [T1562.008, T1485]
+
+state:
+  aws_region:      us-west-2
+  account_id:      "111111111111"
+  actor:           gen.aws_identity(type=IAMUser, userName=attacker-cli, accountId=ref.account_id)
+  source_ip:       gen.ipv4()
+  user_agent:      "aws-cli/2.7.3 Python/3.9.13 Darwin/21.5.0 source/x86_64 prompt/off command/logs.delete-log-stream"
+  tls_version:     "TLSv1.3"
+  tls_cipher:      TLS_AES_128_GCM_SHA256
+  log_group_name:  test-logs
+  log_stream_name: "20150601"
+
+steps:
+  - emit:
+      event_type: aws.cloudtrail@v1
+      fields:
+        eventVersion:       "1.09"
+        eventTime:          gen.timestamp()
+        eventID:            gen.uuid()
+        eventSource:        logs.amazonaws.com
+        eventName:          DeleteLogStream
+        eventType:          AwsApiCall
+        eventCategory:      Management
+        awsRegion:          ref.aws_region
+        sourceIPAddress:    ref.source_ip
+        userAgent:          ref.user_agent
+        requestID:          gen.uuid()
+        requestParameters:
+          logGroupName:  ref.log_group_name
+          logStreamName: ref.log_stream_name
+        responseElements:   null
+        readOnly:           false
+        managementEvent:    true
+        recipientAccountId: ref.account_id
+        userIdentity:       ref.actor
+        tlsDetails:
+          tlsVersion:               ref.tls_version
+          cipherSuite:              ref.tls_cipher
+          clientProvidedHostHeader: "logs.${ref.aws_region}.amazonaws.com"

--- a/scenarios/aws/logs/delete-log-stream.yaml
+++ b/scenarios/aws/logs/delete-log-stream.yaml
@@ -4,7 +4,7 @@ description: |
   destroy archived log events and break audit trails.
 mitre:
   tactics: [defense-evasion, impact]
-  techniques: [T1562.008, T1485]
+  techniques: [T1685.002, T1485]
 
 state:
   aws_region:      us-west-2

--- a/scenarios/aws/waf/delete-rule.yaml
+++ b/scenarios/aws/waf/delete-rule.yaml
@@ -1,0 +1,47 @@
+type: scenario
+description: |
+  Defense evasion: actor deletes an AWS WAF Classic rule, removing a
+  request-matching rule from the protection set.
+mitre:
+  tactics: [defense-evasion]
+  techniques: [T1562.008]
+
+state:
+  aws_region:    us-east-1
+  account_id:    "111111111111"
+  actor:         gen.aws_identity(type=IAMUser, userName=attacker-cli, accountId=ref.account_id)
+  source_ip:     gen.ipv4()
+  user_agent:    "aws-cli/2.7.3 Python/3.9.13 Darwin/21.5.0 source/x86_64 prompt/off command/waf.delete-rule"
+  tls_version:   "TLSv1.3"
+  tls_cipher:    TLS_AES_128_GCM_SHA256
+  change_token:  gen.uuid()
+  rule_id:       gen.uuid()
+
+steps:
+  - emit:
+      event_type: aws.cloudtrail@v1
+      fields:
+        eventVersion:       "1.09"
+        eventTime:          gen.timestamp()
+        eventID:            gen.uuid()
+        eventSource:        waf.amazonaws.com
+        eventName:          DeleteRule
+        eventType:          AwsApiCall
+        eventCategory:      Management
+        awsRegion:          ref.aws_region
+        sourceIPAddress:    ref.source_ip
+        userAgent:          ref.user_agent
+        requestID:          gen.uuid()
+        requestParameters:
+          changeToken: ref.change_token
+          ruleId:      ref.rule_id
+        responseElements:
+          changeToken: ref.change_token
+        readOnly:           false
+        managementEvent:    true
+        recipientAccountId: ref.account_id
+        userIdentity:       ref.actor
+        tlsDetails:
+          tlsVersion:               ref.tls_version
+          cipherSuite:              ref.tls_cipher
+          clientProvidedHostHeader: "waf.amazonaws.com"

--- a/scenarios/aws/waf/delete-rule.yaml
+++ b/scenarios/aws/waf/delete-rule.yaml
@@ -4,7 +4,7 @@ description: |
   request-matching rule from the protection set.
 mitre:
   tactics: [defense-evasion]
-  techniques: [T1562.008]
+  techniques: [T1686.001]
 
 state:
   aws_region:    us-east-1

--- a/scenarios/aws/waf/delete-webacl.yaml
+++ b/scenarios/aws/waf/delete-webacl.yaml
@@ -4,7 +4,7 @@ description: |
   the protection enforcement point for one or more resources.
 mitre:
   tactics: [defense-evasion]
-  techniques: [T1562.008]
+  techniques: [T1686.001]
 
 state:
   aws_region:    us-east-1

--- a/scenarios/aws/waf/delete-webacl.yaml
+++ b/scenarios/aws/waf/delete-webacl.yaml
@@ -1,0 +1,47 @@
+type: scenario
+description: |
+  Defense evasion: actor deletes an AWS WAF Classic web ACL, removing
+  the protection enforcement point for one or more resources.
+mitre:
+  tactics: [defense-evasion]
+  techniques: [T1562.008]
+
+state:
+  aws_region:    us-east-1
+  account_id:    "111111111111"
+  actor:         gen.aws_identity(type=IAMUser, userName=attacker-cli, accountId=ref.account_id)
+  source_ip:     gen.ipv4()
+  user_agent:    "aws-cli/2.7.3 Python/3.9.13 Darwin/21.5.0 source/x86_64 prompt/off command/waf.delete-web-acl"
+  tls_version:   "TLSv1.3"
+  tls_cipher:    TLS_AES_128_GCM_SHA256
+  change_token:  gen.uuid()
+  webacl_id:     gen.uuid()
+
+steps:
+  - emit:
+      event_type: aws.cloudtrail@v1
+      fields:
+        eventVersion:       "1.09"
+        eventTime:          gen.timestamp()
+        eventID:            gen.uuid()
+        eventSource:        waf.amazonaws.com
+        eventName:          DeleteWebACL
+        eventType:          AwsApiCall
+        eventCategory:      Management
+        awsRegion:          ref.aws_region
+        sourceIPAddress:    ref.source_ip
+        userAgent:          ref.user_agent
+        requestID:          gen.uuid()
+        requestParameters:
+          changeToken: ref.change_token
+          webACLId:    ref.webacl_id
+        responseElements:
+          changeToken: ref.change_token
+        readOnly:           false
+        managementEvent:    true
+        recipientAccountId: ref.account_id
+        userIdentity:       ref.actor
+        tlsDetails:
+          tlsVersion:               ref.tls_version
+          cipherSuite:              ref.tls_cipher
+          clientProvidedHostHeader: "waf.amazonaws.com"


### PR DESCRIPTION
- Add `aws-defense-evasion-impair-security-services.yaml` validation job to model deletion API calls across GuardDuty, WAF Classic, and CloudWatch Logs services.
- Add scenarios for deleting GuardDuty detector, IP set, WAF rule, web ACL, and CloudWatch Logs stream.
- Classify workloads under the MITRE defense-evasion tactic with relevant techniques (T1562.008, T1485).