### PR TITLE
Scenario AWS KMS wildcard encrypt policy misuse (T1486)

### DIFF
--- a/jobs/splunk/aws/kms/aws-detect-users-creating-keys-with-encrypt-policy-without-m.yaml
+++ b/jobs/splunk/aws/kms/aws-detect-users-creating-keys-with-encrypt-policy-without-m.yaml
@@ -1,0 +1,42 @@
+type: job
+description: |
+  Validation job for AWS Detect Users creating keys with encrypt policy without MFA.
+  Exercises CreateKey and PutKeyPolicy events whose attached resource
+  policy grants kms:Encrypt to every AWS principal (Principal.AWS="*"),
+  the ransomware-cloud pattern the analytic targets.
+
+mitre:
+  tactics: [impact]
+  techniques: [T1486]
+
+tags: [ransomware-cloud]
+
+state:
+  aws_region:  us-east-1
+  account_id:  "111122223333"
+  source_ip:   gen.ipv4()
+  user_agent:  "aws-cli/2.15.30 Python/3.11.8 Linux/5.15.0-101-generic source/x86_64 tracemill/1.0"
+  actor:       gen.aws_identity(type=IAMUser, userName=attacker-user, accountId=ref.account_id)
+  key_id:      gen.uuid()
+
+workloads:
+  - scenario: scenarios/aws/kms/create-key-wildcard-encrypt-policy
+    bindings:
+      aws_region: ref.aws_region
+      account_id: ref.account_id
+      source_ip:  ref.source_ip
+      user_agent: ref.user_agent
+      actor:      ref.actor
+      key_id:     ref.key_id
+    detection:
+      expected: alert
+  - scenario: scenarios/aws/kms/put-key-policy-wildcard-encrypt
+    bindings:
+      aws_region: ref.aws_region
+      account_id: ref.account_id
+      source_ip:  ref.source_ip
+      user_agent: ref.user_agent
+      actor:      ref.actor
+      key_id:     ref.key_id
+    detection:
+      expected: alert

--- a/jobs/splunk/aws/kms/aws-kms-wildcard-encrypt-policy.yaml
+++ b/jobs/splunk/aws/kms/aws-kms-wildcard-encrypt-policy.yaml
@@ -30,6 +30,7 @@ workloads:
       actor:      ref.actor
       key_id:     ref.key_id
     detection:
+      attack: "AWS KMS wildcard kms:Encrypt key-policy mutation — ransomware-cloud"
       expected: alert
   - scenario: scenarios/aws/kms/put-key-policy-wildcard-encrypt
     bindings:
@@ -40,4 +41,5 @@ workloads:
       actor:      ref.actor
       key_id:     ref.key_id
     detection:
+      attack: "AWS KMS wildcard kms:Encrypt key-policy mutation — ransomware-cloud"
       expected: alert

--- a/jobs/splunk/aws/kms/aws-kms-wildcard-encrypt-policy.yaml
+++ b/jobs/splunk/aws/kms/aws-kms-wildcard-encrypt-policy.yaml
@@ -1,9 +1,10 @@
 type: job
 description: |
-  Validation job for AWS Detect Users creating keys with encrypt policy without MFA.
-  Exercises CreateKey and PutKeyPolicy events whose attached resource
-  policy grants kms:Encrypt to every AWS principal (Principal.AWS="*"),
-  the ransomware-cloud pattern the analytic targets.
+  Exercises CreateKey and PutKeyPolicy CloudTrail events whose attached
+  resource policy grants kms:Encrypt to every AWS principal
+  (Principal.AWS="*"), the ransomware-cloud pattern where a compromised
+  account publishes a wildcard-encrypt grant on a KMS key so any
+  outside principal can re-encrypt victim assets.
 
 mitre:
   tactics: [impact]

--- a/scenarios/aws/kms/create-key-wildcard-encrypt-policy.yaml
+++ b/scenarios/aws/kms/create-key-wildcard-encrypt-policy.yaml
@@ -25,8 +25,8 @@ state:
   account_root_arn: "arn:aws:iam::${ref.account_id}:root"
   malicious_policy: |-
     {
-        "Id": "key-consolepolicy-3",
         "Version": "2012-10-17",
+        "Id": "key-consolepolicy-3",
         "Statement": [
             {
                 "Sid": "Enable IAM User Permissions",

--- a/scenarios/aws/kms/create-key-wildcard-encrypt-policy.yaml
+++ b/scenarios/aws/kms/create-key-wildcard-encrypt-policy.yaml
@@ -1,0 +1,123 @@
+type: scenario
+description: |
+  Impact / ransomware: actor creates a customer-managed KMS key whose
+  attached resource policy grants kms:Encrypt to every AWS principal
+  (Principal.AWS="*"). The wildcard grant lets any outside identity use
+  the key to encrypt data, enabling cross-account ransomware patterns
+  where the attacker re-encrypts victim assets under their own key.
+mitre:
+  tactics: [impact]
+  techniques: [T1486]
+
+tags: [ransomware-cloud]
+
+state:
+  aws_region:    us-east-1
+  account_id:    "000000000000"
+  actor:         gen.aws_identity(type=IAMUser, userName=attacker-user, accountId=ref.account_id)
+  source_ip:     gen.ipv4()
+  user_agent:    "aws-cli/2.15.30 Python/3.11.8 Linux/5.15.0-101-generic source/x86_64 tracemill/1.0"
+  tls_version:   "TLSv1.3"
+  tls_cipher:    TLS_AES_128_GCM_SHA256
+  key_id:        gen.uuid()
+  key_arn:       "arn:aws:kms:${ref.aws_region}:${ref.account_id}:key/${ref.key_id}"
+  key_admin_arn: "arn:aws:iam::${ref.account_id}:user/key-admin"
+  account_root_arn: "arn:aws:iam::${ref.account_id}:root"
+  malicious_policy: |-
+    {
+        "Id": "key-consolepolicy-3",
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "Enable IAM User Permissions",
+                "Effect": "Allow",
+                "Principal": {
+                    "AWS": "${ref.account_root_arn}"
+                },
+                "Action": "kms:*",
+                "Resource": "*"
+            },
+            {
+                "Sid": "Allow access for Key Administrators",
+                "Effect": "Allow",
+                "Principal": {
+                    "AWS": "${ref.key_admin_arn}"
+                },
+                "Action": [
+                    "kms:Create*",
+                    "kms:Describe*",
+                    "kms:Enable*",
+                    "kms:List*",
+                    "kms:Put*",
+                    "kms:Update*",
+                    "kms:Revoke*",
+                    "kms:Disable*",
+                    "kms:Get*",
+                    "kms:Delete*",
+                    "kms:TagResource",
+                    "kms:UntagResource",
+                    "kms:ScheduleKeyDeletion",
+                    "kms:CancelKeyDeletion"
+                ],
+                "Resource": "*"
+            },
+            {
+                "Sid": "Allow use of the key",
+                "Effect": "Allow",
+                "Principal": {
+                    "AWS": "*"
+                },
+                "Action": [
+                    "kms:Encrypt"
+                ],
+                "Resource": "*"
+            }
+        ]
+    }
+
+steps:
+  - emit:
+      event_type: aws.cloudtrail@v1
+      fields:
+        eventVersion:       "1.08"
+        eventTime:          gen.timestamp()
+        eventID:            gen.uuid()
+        eventSource:        kms.amazonaws.com
+        eventName:          CreateKey
+        eventType:          AwsApiCall
+        eventCategory:      Management
+        awsRegion:          ref.aws_region
+        sourceIPAddress:    ref.source_ip
+        userAgent:          ref.user_agent
+        requestID:          gen.uuid()
+        requestParameters:
+          origin:                       AWS_KMS
+          policy:                       ref.malicious_policy
+          description:                  ""
+          customerMasterKeySpec:        SYMMETRIC_DEFAULT
+          bypassPolicyLockoutSafetyCheck: false
+          tags:                         []
+          keyUsage:                     ENCRYPT_DECRYPT
+        responseElements:
+          keyMetadata:
+            aWSAccountId:           ref.account_id
+            keyId:                  ref.key_id
+            arn:                    ref.key_arn
+            creationDate:           gen.timestamp()
+            enabled:                true
+            description:            ""
+            keyUsage:               ENCRYPT_DECRYPT
+            keyState:               Enabled
+            origin:                 AWS_KMS
+            keyManager:             CUSTOMER
+            customerMasterKeySpec:  SYMMETRIC_DEFAULT
+            encryptionAlgorithms:
+              - SYMMETRIC_DEFAULT
+        readOnly:           false
+        managementEvent:    true
+        recipientAccountId: ref.account_id
+        userIdentity:       ref.actor
+        resources:
+          - accountId: ref.account_id
+            type:      "AWS::KMS::Key"
+            ARN:       ref.key_arn

--- a/scenarios/aws/kms/create-key-wildcard-encrypt-policy.yaml
+++ b/scenarios/aws/kms/create-key-wildcard-encrypt-policy.yaml
@@ -12,17 +12,19 @@ mitre:
 tags: [ransomware-cloud]
 
 state:
-  aws_region:    us-east-1
-  account_id:    "000000000000"
-  actor:         gen.aws_identity(type=IAMUser, userName=attacker-user, accountId=ref.account_id)
-  source_ip:     gen.ipv4()
-  user_agent:    "aws-cli/2.15.30 Python/3.11.8 Linux/5.15.0-101-generic source/x86_64 tracemill/1.0"
-  tls_version:   "TLSv1.3"
-  tls_cipher:    TLS_AES_128_GCM_SHA256
-  key_id:        gen.uuid()
-  key_arn:       "arn:aws:kms:${ref.aws_region}:${ref.account_id}:key/${ref.key_id}"
-  key_admin_arn: "arn:aws:iam::${ref.account_id}:user/key-admin"
+  aws_region:       us-east-1
+  account_id:       "000000000000"
+  actor:            gen.aws_identity(type=IAMUser, userName=attacker-user, accountId=ref.account_id)
+  source_ip:        gen.ipv4()
+  user_agent:       "aws-cli/2.31.27 md/awscrt#0.27.6 ua/2.1 os/linux md/arch#x86_64 lang/python#3.13.9 md/pyimpl#CPython cfg/retry-mode#standard md/command#kms.create-key tracemill/1.0"
+  key_id:           gen.uuid()
+  key_arn:          "arn:aws:kms:${ref.aws_region}:${ref.account_id}:key/${ref.key_id}"
   account_root_arn: "arn:aws:iam::${ref.account_id}:root"
+  # 32-byte sha256-shaped hex literal; KMS surfaces this as
+  # currentKeyMaterialId on every CreateKey response. No gen.* generator
+  # produces this shape today (see skill issue log), so the value is
+  # pinned; jobs can override via state binding for per-run variability.
+  key_material_id:  "ac08703a85513650d3cda0a2c0e151139ac95d3f48e5423ff8b53d79e0668f35"
   malicious_policy: |-
     {
         "Version": "2012-10-17",
@@ -31,45 +33,15 @@ state:
             {
                 "Sid": "Enable IAM User Permissions",
                 "Effect": "Allow",
-                "Principal": {
-                    "AWS": "${ref.account_root_arn}"
-                },
+                "Principal": { "AWS": "${ref.account_root_arn}" },
                 "Action": "kms:*",
-                "Resource": "*"
-            },
-            {
-                "Sid": "Allow access for Key Administrators",
-                "Effect": "Allow",
-                "Principal": {
-                    "AWS": "${ref.key_admin_arn}"
-                },
-                "Action": [
-                    "kms:Create*",
-                    "kms:Describe*",
-                    "kms:Enable*",
-                    "kms:List*",
-                    "kms:Put*",
-                    "kms:Update*",
-                    "kms:Revoke*",
-                    "kms:Disable*",
-                    "kms:Get*",
-                    "kms:Delete*",
-                    "kms:TagResource",
-                    "kms:UntagResource",
-                    "kms:ScheduleKeyDeletion",
-                    "kms:CancelKeyDeletion"
-                ],
                 "Resource": "*"
             },
             {
                 "Sid": "Allow use of the key",
                 "Effect": "Allow",
-                "Principal": {
-                    "AWS": "*"
-                },
-                "Action": [
-                    "kms:Encrypt"
-                ],
+                "Principal": { "AWS": "*" },
+                "Action": [ "kms:Encrypt" ],
                 "Resource": "*"
             }
         ]
@@ -79,7 +51,7 @@ steps:
   - emit:
       event_type: aws.cloudtrail@v1
       fields:
-        eventVersion:       "1.08"
+        eventVersion:       "1.11"
         eventTime:          gen.timestamp()
         eventID:            gen.uuid()
         eventSource:        kms.amazonaws.com
@@ -91,28 +63,34 @@ steps:
         userAgent:          ref.user_agent
         requestID:          gen.uuid()
         requestParameters:
-          origin:                       AWS_KMS
-          policy:                       ref.malicious_policy
-          description:                  ""
-          customerMasterKeySpec:        SYMMETRIC_DEFAULT
-          bypassPolicyLockoutSafetyCheck: false
-          tags:                         []
-          keyUsage:                     ENCRYPT_DECRYPT
+          bypassPolicyLockoutSafetyCheck: true
+          customerMasterKeySpec:          SYMMETRIC_DEFAULT
+          description:                    "tracemill ransomware-cloud scenario: KMS key with wildcard kms:Encrypt grant"
+          tags:
+            - tagKey:   tracemill
+              tagValue: ransomware-cloud-scenario
+          policy:                         ref.malicious_policy
+          keyUsage:                       ENCRYPT_DECRYPT
+          keySpec:                        SYMMETRIC_DEFAULT
+          origin:                         AWS_KMS
         responseElements:
           keyMetadata:
-            aWSAccountId:           ref.account_id
-            keyId:                  ref.key_id
-            arn:                    ref.key_arn
-            creationDate:           gen.timestamp()
-            enabled:                true
-            description:            ""
-            keyUsage:               ENCRYPT_DECRYPT
-            keyState:               Enabled
-            origin:                 AWS_KMS
-            keyManager:             CUSTOMER
-            customerMasterKeySpec:  SYMMETRIC_DEFAULT
+            aWSAccountId:          ref.account_id
+            keyId:                 ref.key_id
+            arn:                   ref.key_arn
+            creationDate:          gen.timestamp()
+            enabled:               true
+            description:           "tracemill ransomware-cloud scenario: KMS key with wildcard kms:Encrypt grant"
+            keyUsage:              ENCRYPT_DECRYPT
+            keyState:              Enabled
+            origin:                AWS_KMS
+            keyManager:            CUSTOMER
+            customerMasterKeySpec: SYMMETRIC_DEFAULT
+            keySpec:               SYMMETRIC_DEFAULT
             encryptionAlgorithms:
               - SYMMETRIC_DEFAULT
+            multiRegion:           false
+            currentKeyMaterialId:  ref.key_material_id
         readOnly:           false
         managementEvent:    true
         recipientAccountId: ref.account_id
@@ -121,3 +99,8 @@ steps:
           - accountId: ref.account_id
             type:      "AWS::KMS::Key"
             ARN:       ref.key_arn
+        tlsDetails:
+          tlsVersion:               "TLSv1.3"
+          cipherSuite:              "TLS_AES_256_GCM_SHA384"
+          clientProvidedHostHeader: "kms.${ref.aws_region}.amazonaws.com"
+          keyExchange:              "x25519"

--- a/scenarios/aws/kms/put-key-policy-wildcard-encrypt.yaml
+++ b/scenarios/aws/kms/put-key-policy-wildcard-encrypt.yaml
@@ -1,0 +1,107 @@
+type: scenario
+description: |
+  Impact / ransomware: actor replaces an existing customer-managed KMS
+  key's resource policy with one that grants kms:Encrypt to every AWS
+  principal (Principal.AWS="*"). The wildcard grant lets any outside
+  identity use the key to encrypt data, enabling cross-account
+  ransomware patterns where the attacker re-encrypts victim assets
+  under their own key.
+mitre:
+  tactics: [impact]
+  techniques: [T1486]
+
+tags: [ransomware-cloud]
+
+state:
+  aws_region:    us-east-1
+  account_id:    "000000000000"
+  actor:         gen.aws_identity(type=IAMUser, userName=attacker-user, accountId=ref.account_id)
+  source_ip:     gen.ipv4()
+  user_agent:    "aws-cli/2.15.30 Python/3.11.8 Linux/5.15.0-101-generic source/x86_64 tracemill/1.0"
+  tls_version:   "TLSv1.3"
+  tls_cipher:    TLS_AES_128_GCM_SHA256
+  key_id:        gen.uuid()
+  key_arn:       "arn:aws:kms:${ref.aws_region}:${ref.account_id}:key/${ref.key_id}"
+  key_admin_arn: "arn:aws:iam::${ref.account_id}:user/key-admin"
+  account_root_arn: "arn:aws:iam::${ref.account_id}:root"
+  malicious_policy: |-
+    {
+        "Version": "2012-10-17",
+        "Id": "key-consolepolicy-3",
+        "Statement": [
+            {
+                "Sid": "Enable IAM User Permissions",
+                "Effect": "Allow",
+                "Principal": {
+                    "AWS": "${ref.account_root_arn}"
+                },
+                "Action": "kms:*",
+                "Resource": "*"
+            },
+            {
+                "Sid": "Allow access for Key Administrators",
+                "Effect": "Allow",
+                "Principal": {
+                    "AWS": "${ref.key_admin_arn}"
+                },
+                "Action": [
+                    "kms:Create*",
+                    "kms:Describe*",
+                    "kms:Enable*",
+                    "kms:List*",
+                    "kms:Put*",
+                    "kms:Update*",
+                    "kms:Revoke*",
+                    "kms:Disable*",
+                    "kms:Get*",
+                    "kms:Delete*",
+                    "kms:TagResource",
+                    "kms:UntagResource",
+                    "kms:ScheduleKeyDeletion",
+                    "kms:CancelKeyDeletion"
+                ],
+                "Resource": "*"
+            },
+            {
+                "Sid": "Allow use of the key",
+                "Effect": "Allow",
+                "Principal": {
+                    "AWS": "*"
+                },
+                "Action": [
+                    "kms:Encrypt"
+                ],
+                "Resource": "*"
+            }
+        ]
+    }
+
+steps:
+  - emit:
+      event_type: aws.cloudtrail@v1
+      fields:
+        eventVersion:       "1.08"
+        eventTime:          gen.timestamp()
+        eventID:            gen.uuid()
+        eventSource:        kms.amazonaws.com
+        eventName:          PutKeyPolicy
+        eventType:          AwsApiCall
+        eventCategory:      Management
+        awsRegion:          ref.aws_region
+        sourceIPAddress:    ref.source_ip
+        userAgent:          ref.user_agent
+        requestID:          gen.uuid()
+        requestParameters:
+          keyId:                          ref.key_id
+          policyName:                     default
+          policy:                         ref.malicious_policy
+          bypassPolicyLockoutSafetyCheck: false
+        responseElements:   null
+        readOnly:           false
+        managementEvent:    true
+        recipientAccountId: ref.account_id
+        userIdentity:       ref.actor
+        resources:
+          - accountId: ref.account_id
+            type:      "AWS::KMS::Key"
+            ARN:       ref.key_arn

--- a/scenarios/aws/kms/put-key-policy-wildcard-encrypt.yaml
+++ b/scenarios/aws/kms/put-key-policy-wildcard-encrypt.yaml
@@ -13,16 +13,13 @@ mitre:
 tags: [ransomware-cloud]
 
 state:
-  aws_region:    us-east-1
-  account_id:    "000000000000"
-  actor:         gen.aws_identity(type=IAMUser, userName=attacker-user, accountId=ref.account_id)
-  source_ip:     gen.ipv4()
-  user_agent:    "aws-cli/2.15.30 Python/3.11.8 Linux/5.15.0-101-generic source/x86_64 tracemill/1.0"
-  tls_version:   "TLSv1.3"
-  tls_cipher:    TLS_AES_128_GCM_SHA256
-  key_id:        gen.uuid()
-  key_arn:       "arn:aws:kms:${ref.aws_region}:${ref.account_id}:key/${ref.key_id}"
-  key_admin_arn: "arn:aws:iam::${ref.account_id}:user/key-admin"
+  aws_region:       us-east-1
+  account_id:       "000000000000"
+  actor:            gen.aws_identity(type=IAMUser, userName=attacker-user, accountId=ref.account_id)
+  source_ip:        gen.ipv4()
+  user_agent:       "aws-cli/2.31.27 md/awscrt#0.27.6 ua/2.1 os/linux md/arch#x86_64 lang/python#3.13.9 md/pyimpl#CPython cfg/retry-mode#standard md/command#kms.put-key-policy tracemill/1.0"
+  key_id:           gen.uuid()
+  key_arn:          "arn:aws:kms:${ref.aws_region}:${ref.account_id}:key/${ref.key_id}"
   account_root_arn: "arn:aws:iam::${ref.account_id}:root"
   malicious_policy: |-
     {
@@ -32,45 +29,15 @@ state:
             {
                 "Sid": "Enable IAM User Permissions",
                 "Effect": "Allow",
-                "Principal": {
-                    "AWS": "${ref.account_root_arn}"
-                },
+                "Principal": { "AWS": "${ref.account_root_arn}" },
                 "Action": "kms:*",
-                "Resource": "*"
-            },
-            {
-                "Sid": "Allow access for Key Administrators",
-                "Effect": "Allow",
-                "Principal": {
-                    "AWS": "${ref.key_admin_arn}"
-                },
-                "Action": [
-                    "kms:Create*",
-                    "kms:Describe*",
-                    "kms:Enable*",
-                    "kms:List*",
-                    "kms:Put*",
-                    "kms:Update*",
-                    "kms:Revoke*",
-                    "kms:Disable*",
-                    "kms:Get*",
-                    "kms:Delete*",
-                    "kms:TagResource",
-                    "kms:UntagResource",
-                    "kms:ScheduleKeyDeletion",
-                    "kms:CancelKeyDeletion"
-                ],
                 "Resource": "*"
             },
             {
                 "Sid": "Allow use of the key",
                 "Effect": "Allow",
-                "Principal": {
-                    "AWS": "*"
-                },
-                "Action": [
-                    "kms:Encrypt"
-                ],
+                "Principal": { "AWS": "*" },
+                "Action": [ "kms:Encrypt" ],
                 "Resource": "*"
             }
         ]
@@ -80,7 +47,7 @@ steps:
   - emit:
       event_type: aws.cloudtrail@v1
       fields:
-        eventVersion:       "1.08"
+        eventVersion:       "1.11"
         eventTime:          gen.timestamp()
         eventID:            gen.uuid()
         eventSource:        kms.amazonaws.com
@@ -95,8 +62,9 @@ steps:
           keyId:                          ref.key_id
           policyName:                     default
           policy:                         ref.malicious_policy
-          bypassPolicyLockoutSafetyCheck: false
-        responseElements:   null
+          bypassPolicyLockoutSafetyCheck: true
+        responseElements:
+          keyId: ref.key_arn
         readOnly:           false
         managementEvent:    true
         recipientAccountId: ref.account_id
@@ -105,3 +73,8 @@ steps:
           - accountId: ref.account_id
             type:      "AWS::KMS::Key"
             ARN:       ref.key_arn
+        tlsDetails:
+          tlsVersion:               "TLSv1.3"
+          cipherSuite:              "TLS_AES_256_GCM_SHA384"
+          clientProvidedHostHeader: "kms.${ref.aws_region}.amazonaws.com"
+          keyExchange:              "x25519"


### PR DESCRIPTION
- Add `aws-kms-wildcard-encrypt-policy.yaml` job targeting the upstream Splunk ESCU detection for KMS key creation or policy updates granting `kms:Encrypt` to all principals (`Principal.AWS="*"`).
- Add supporting scenarios `create-key-wildcard-encrypt-policy.yaml` and `put-key-policy-wildcard-encrypt.yaml` modeling the attacker behaviors that enable cross-account ransomware patterns.
- Classified workloads under MITRE `impact` tactic using technique `T1486`.
