### PR TITLE
Add S3 PutBucketAcl public-access scenarios + validation job

### DIFF
--- a/jobs/splunk/aws/s3/detect-new-open-s3-buckets.yaml
+++ b/jobs/splunk/aws/s3/detect-new-open-s3-buckets.yaml
@@ -1,0 +1,25 @@
+type: job
+description: |
+  Validation job for the Detect New Open S3 buckets detection (T1530).
+
+  Exercises three PutBucketAcl methods that grant the AllUsers group
+  public read access -- the XML body grant form, the x-amz-grant-read
+  header form, and the public-read canned ACL -- plus a benign
+  owner-only ACL control.
+mitre:
+  tactics: [collection]
+  techniques: [T1530]
+
+workloads:
+  - scenario: scenarios/aws/s3/make-bucket-public-acl
+    expectation:
+      expected: alert
+  - scenario: scenarios/aws/s3/put-bucket-acl-private
+    expectation:
+      expected: none
+  - scenario: scenarios/aws/s3/put-bucket-acl-header-form
+    expectation:
+      expected: alert
+  - scenario: scenarios/aws/s3/put-bucket-acl-canned-acl
+    expectation:
+      expected: alert

--- a/scenarios/aws/s3/make-bucket-public-acl.yaml
+++ b/scenarios/aws/s3/make-bucket-public-acl.yaml
@@ -1,0 +1,84 @@
+type: scenario
+description: |
+  An actor sets an S3 bucket ACL via the XML body form of PutBucketAcl,
+  granting the AllUsers group READ and READ_ACP permissions. This makes
+  the bucket publicly readable and exposes its contents to any unauthenticated
+  requester.
+mitre:
+  tactics: [collection]
+  techniques: [T1530]
+
+state:
+  aws_region:  us-east-1
+  account_id:  "000000000000"
+  actor:       gen.aws_identity(type=AssumedRole, accountId=ref.account_id)
+  source_ip:   gen.ipv4()
+  user_agent:  "[S3Console/0.4, aws-internal/3 aws-sdk-java/1.11.915 Linux/4.9.230-0.1.ac.223 OpenJDK_64-Bit_Server_VM/25.275-b01 java/1.8.0_275 vendor/Oracle_Corporation tracemill/1.0]"
+  bucket_name: gen.username()
+  bucket_arn:  "arn:aws:s3:::${ref.bucket_name}"
+  bucket_host: "${ref.bucket_name}.s3.${ref.aws_region}.amazonaws.com"
+  owner_id:    gen.hex(len=64, case=lower)
+  request_id:  gen.hex(len=16, case=upper)
+  amz_id2:     gen.hex(len=76, case=lower)
+
+steps:
+  - emit:
+      event_type: aws.cloudtrail@v1
+      fields:
+        eventVersion:       "1.11"
+        eventTime:          gen.timestamp()
+        eventID:            gen.uuid()
+        eventSource:        s3.amazonaws.com
+        eventName:          PutBucketAcl
+        eventType:          AwsApiCall
+        eventCategory:      Management
+        awsRegion:          ref.aws_region
+        sourceIPAddress:    ref.source_ip
+        userAgent:          ref.user_agent
+        requestID:          ref.request_id
+        requestParameters:
+          bucketName: ref.bucket_name
+          Host:       ref.bucket_host
+          acl:        ""
+          AccessControlPolicy:
+            xmlns: "http://s3.amazonaws.com/doc/2006-03-01/"
+            Owner:
+              ID: ref.owner_id
+            AccessControlList:
+              Grant:
+                - Grantee:
+                    "xsi:type":  CanonicalUser
+                    "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance"
+                    ID:          ref.owner_id
+                  Permission: FULL_CONTROL
+                - Grantee:
+                    "xsi:type":  Group
+                    "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance"
+                    URI:         "http://acs.amazonaws.com/groups/global/AllUsers"
+                  Permission: READ
+                - Grantee:
+                    "xsi:type":  Group
+                    "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance"
+                    URI:         "http://acs.amazonaws.com/groups/global/AllUsers"
+                  Permission: READ_ACP
+        responseElements:   null
+        readOnly:           false
+        managementEvent:    true
+        recipientAccountId: ref.account_id
+        userIdentity:       ref.actor
+        additionalEventData:
+          SignatureVersion:     SigV4
+          CipherSuite:          TLS_AES_128_GCM_SHA256
+          AuthenticationMethod: AuthHeader
+          aclRequired:          "Yes"
+          bytesTransferredIn:   0
+          bytesTransferredOut:  0
+          "x-amz-id-2":         ref.amz_id2
+        tlsDetails:
+          tlsVersion:               TLSv1.3
+          cipherSuite:              TLS_AES_128_GCM_SHA256
+          clientProvidedHostHeader: ref.bucket_host
+        resources:
+          - accountId: ref.account_id
+            type:      "AWS::S3::Bucket"
+            ARN:       ref.bucket_arn

--- a/scenarios/aws/s3/put-bucket-acl-canned-acl.yaml
+++ b/scenarios/aws/s3/put-bucket-acl-canned-acl.yaml
@@ -1,0 +1,63 @@
+type: scenario
+description: |
+  An actor sets an S3 bucket to the public-read canned ACL using the x-amz-acl
+  header in a PutBucketAcl request. The canned ACL grants the AllUsers group
+  read access to the bucket and its objects without specifying explicit grants
+  in the request body or individual grant headers.
+mitre:
+  tactics: [collection]
+  techniques: [T1530]
+
+state:
+  aws_region:  us-east-1
+  account_id:  "000000000000"
+  actor:       gen.aws_identity(type=IAMUser, accountId=ref.account_id)
+  source_ip:   gen.ipv4()
+  user_agent:  "[aws-cli/2.0.45 Python/3.7.4 Darwin/20.2.0 exe/x86_64 command/s3api.put-bucket-acl tracemill/1.0]"
+  bucket_name: gen.username()
+  bucket_arn:  "arn:aws:s3:::${ref.bucket_name}"
+  bucket_host: "${ref.bucket_name}.s3.${ref.aws_region}.amazonaws.com"
+  request_id:  gen.hex(len=16, case=upper)
+  amz_id2:     gen.hex(len=76, case=lower)
+
+steps:
+  - emit:
+      event_type: aws.cloudtrail@v1
+      fields:
+        eventVersion:       "1.11"
+        eventTime:          gen.timestamp()
+        eventID:            gen.uuid()
+        eventSource:        s3.amazonaws.com
+        eventName:          PutBucketAcl
+        eventType:          AwsApiCall
+        eventCategory:      Management
+        awsRegion:          ref.aws_region
+        sourceIPAddress:    ref.source_ip
+        userAgent:          ref.user_agent
+        requestID:          ref.request_id
+        requestParameters:
+          bucketName:  ref.bucket_name
+          Host:        ref.bucket_host
+          acl:         ""
+          "x-amz-acl": public-read
+        responseElements:   null
+        readOnly:           false
+        managementEvent:    true
+        recipientAccountId: ref.account_id
+        userIdentity:       ref.actor
+        additionalEventData:
+          SignatureVersion:     SigV4
+          CipherSuite:          TLS_AES_128_GCM_SHA256
+          AuthenticationMethod: AuthHeader
+          aclRequired:          "Yes"
+          bytesTransferredIn:   0
+          bytesTransferredOut:  0
+          "x-amz-id-2":         ref.amz_id2
+        tlsDetails:
+          tlsVersion:               TLSv1.3
+          cipherSuite:              TLS_AES_128_GCM_SHA256
+          clientProvidedHostHeader: ref.bucket_host
+        resources:
+          - accountId: ref.account_id
+            type:      "AWS::S3::Bucket"
+            ARN:       ref.bucket_arn

--- a/scenarios/aws/s3/put-bucket-acl-header-form.yaml
+++ b/scenarios/aws/s3/put-bucket-acl-header-form.yaml
@@ -1,0 +1,64 @@
+type: scenario
+description: |
+  An actor grants public read access to an S3 bucket using the HTTP request
+  header form of PutBucketAcl (x-amz-grant-read), specifying the AllUsers
+  group by URI. This exposes the bucket's contents to any unauthenticated
+  requester.
+mitre:
+  tactics: [collection]
+  techniques: [T1530]
+
+state:
+  aws_region:  us-east-1
+  account_id:  "000000000000"
+  actor:       gen.aws_identity(type=IAMUser, accountId=ref.account_id)
+  source_ip:   gen.ipv4()
+  user_agent:  "[aws-cli/2.0.45 Python/3.7.4 Darwin/20.2.0 exe/x86_64 command/s3api.put-bucket-acl tracemill/1.0]"
+  bucket_name: gen.username()
+  bucket_arn:  "arn:aws:s3:::${ref.bucket_name}"
+  bucket_host: "${ref.bucket_name}.s3.${ref.aws_region}.amazonaws.com"
+  request_id:  gen.hex(len=16, case=upper)
+  amz_id2:     gen.hex(len=76, case=lower)
+
+steps:
+  - emit:
+      event_type: aws.cloudtrail@v1
+      fields:
+        eventVersion:       "1.11"
+        eventTime:          gen.timestamp()
+        eventID:            gen.uuid()
+        eventSource:        s3.amazonaws.com
+        eventName:          PutBucketAcl
+        eventType:          AwsApiCall
+        eventCategory:      Management
+        awsRegion:          ref.aws_region
+        sourceIPAddress:    ref.source_ip
+        userAgent:          ref.user_agent
+        requestID:          ref.request_id
+        requestParameters:
+          bucketName: ref.bucket_name
+          Host:       ref.bucket_host
+          acl:        ""
+          accessControlList:
+            "x-amz-grant-read": "uri=http://acs.amazonaws.com/groups/global/AllUsers"
+        responseElements:   null
+        readOnly:           false
+        managementEvent:    true
+        recipientAccountId: ref.account_id
+        userIdentity:       ref.actor
+        additionalEventData:
+          SignatureVersion:     SigV4
+          CipherSuite:          TLS_AES_128_GCM_SHA256
+          AuthenticationMethod: AuthHeader
+          aclRequired:          "Yes"
+          bytesTransferredIn:   0
+          bytesTransferredOut:  0
+          "x-amz-id-2":         ref.amz_id2
+        tlsDetails:
+          tlsVersion:               TLSv1.3
+          cipherSuite:              TLS_AES_128_GCM_SHA256
+          clientProvidedHostHeader: ref.bucket_host
+        resources:
+          - accountId: ref.account_id
+            type:      "AWS::S3::Bucket"
+            ARN:       ref.bucket_arn

--- a/scenarios/aws/s3/put-bucket-acl-private.yaml
+++ b/scenarios/aws/s3/put-bucket-acl-private.yaml
@@ -1,0 +1,58 @@
+type: scenario
+description: |
+  An actor resets an S3 bucket ACL to private ownership via the XML body form
+  of PutBucketAcl, granting FULL_CONTROL only to the canonical user (bucket
+  owner). No public or authenticated group access is granted. This represents
+  routine ACL management and serves as a benign baseline.
+
+state:
+  aws_region:  us-east-1
+  account_id:  "000000000000"
+  actor:       gen.aws_identity(type=AssumedRole, accountId=ref.account_id)
+  source_ip:   gen.ipv4()
+  user_agent:  "[S3Console/0.4, aws-internal/3 aws-sdk-java/1.11.915 Linux/4.9.230-0.1.ac.223 OpenJDK_64-Bit_Server_VM/25.275-b01 java/1.8.0_275 vendor/Oracle_Corporation tracemill/1.0]"
+  bucket_name: gen.username()
+  bucket_arn:  "arn:aws:s3:::${ref.bucket_name}"
+  bucket_host: "s3.${ref.aws_region}.amazonaws.com"
+  owner_id:    gen.hex(len=64, case=lower)
+  request_id:  gen.hex(len=16, case=upper)
+
+steps:
+  - emit:
+      event_type: aws.cloudtrail@v1
+      fields:
+        eventVersion:       "1.08"
+        eventTime:          gen.timestamp()
+        eventID:            gen.uuid()
+        eventSource:        s3.amazonaws.com
+        eventName:          PutBucketAcl
+        eventType:          AwsApiCall
+        eventCategory:      Management
+        awsRegion:          ref.aws_region
+        sourceIPAddress:    ref.source_ip
+        userAgent:          ref.user_agent
+        requestID:          ref.request_id
+        requestParameters:
+          bucketName: ref.bucket_name
+          Host:       ref.bucket_host
+          acl:        ""
+          AccessControlPolicy:
+            xmlns: "http://s3.amazonaws.com/doc/2006-03-01/"
+            Owner:
+              ID: ref.owner_id
+            AccessControlList:
+              Grant:
+                Grantee:
+                  "xsi:type":  CanonicalUser
+                  "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance"
+                  ID:          ref.owner_id
+                Permission: FULL_CONTROL
+        responseElements:   null
+        readOnly:           false
+        managementEvent:    true
+        recipientAccountId: ref.account_id
+        userIdentity:       ref.actor
+        resources:
+          - accountId: ref.account_id
+            type:      "AWS::S3::Bucket"
+            ARN:       ref.bucket_arn


### PR DESCRIPTION
  - `make-bucket-public-acl` — XML body grant to AllUsers (attack-positive)
  - `put-bucket-acl-header-form` — `x-amz-grant-read` header grant (attack variant)
  - `put-bucket-acl-canned-acl` — `public-read` canned ACL via `x-amz-acl` (attack variant)
  - `put-bucket-acl-private` — benign control