### PR TITLE
AWS EC2 snapshot sharing scenario (T1537)

### DIFF
--- a/jobs/splunk/aws/ec2/aws-ec2-snapshot-shared-externally.yaml
+++ b/jobs/splunk/aws/ec2/aws-ec2-snapshot-shared-externally.yaml
@@ -9,6 +9,9 @@ description: |
   inspect createVolumePermission.add.items[].userId do not observe, because a
   group=all grant carries no userId.
   See https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifySnapshotAttribute.html
+mitre:
+  tactics: [exfiltration]
+  techniques: [T1537]
 workloads:
   - scenario: scenarios/aws/ec2/share-snapshot-external-account
     expectation:

--- a/jobs/splunk/aws/ec2/aws-ec2-snapshot-shared-externally.yaml
+++ b/jobs/splunk/aws/ec2/aws-ec2-snapshot-shared-externally.yaml
@@ -1,0 +1,21 @@
+type: job
+description: |
+  Validation job for AWS EC2 Snapshot Shared Externally. Exercises
+  ModifySnapshotAttribute create-volume-permission changes: sharing an EBS
+  snapshot with an external AWS account (attack), granting permission to the
+  snapshot's own account (benign control), and making the snapshot public via
+  the "all" group. The public-share workload models a broader exfiltration
+  scope (MITRE T1537) that per-account snapshot-sharing detections which only
+  inspect createVolumePermission.add.items[].userId do not observe, because a
+  group=all grant carries no userId.
+  See https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifySnapshotAttribute.html
+workloads:
+  - scenario: scenarios/aws/ec2/share-snapshot-external-account
+    expectation:
+      expected: alert
+  - scenario: scenarios/aws/ec2/share-snapshot-same-account
+    expectation:
+      expected: none
+  - scenario: scenarios/aws/ec2/share-snapshot-public-group-all
+    expectation:
+      expected: alert

--- a/scenarios/aws/ec2/share-snapshot-external-account.yaml
+++ b/scenarios/aws/ec2/share-snapshot-external-account.yaml
@@ -25,7 +25,7 @@ steps:
   - emit:
       event_type: aws.cloudtrail@v1
       fields:
-        eventVersion:       "1.08"
+        eventVersion:       "1.11"
         eventTime:          gen.timestamp()
         eventID:            gen.uuid()
         eventSource:        ec2.amazonaws.com
@@ -51,6 +51,6 @@ steps:
         recipientAccountId: ref.account_id
         userIdentity:       ref.actor
         tlsDetails:
-          tlsVersion:               TLSv1.2
-          cipherSuite:              ECDHE-RSA-AES128-GCM-SHA256
+          tlsVersion:               TLSv1.3
+          cipherSuite:              TLS_AES_128_GCM_SHA256
           clientProvidedHostHeader: "ec2.${ref.aws_region}.amazonaws.com"

--- a/scenarios/aws/ec2/share-snapshot-external-account.yaml
+++ b/scenarios/aws/ec2/share-snapshot-external-account.yaml
@@ -1,0 +1,56 @@
+type: scenario
+description: |
+  An actor shares an EBS snapshot with an external AWS account by calling
+  ModifySnapshotAttribute with createVolumePermission.add granting create-volume
+  permission to an account ID that differs from the snapshot owner. An attacker
+  can then create a volume from the snapshot in the recipient account, moving the
+  snapshot's data outside the owning organization.
+  See https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifySnapshotAttribute.html
+mitre:
+  tactics: [exfiltration]
+  techniques: [T1537]
+
+state:
+  aws_region:          us-west-2
+  account_id:          "111111111111"
+  external_account_id: "012345678912"
+  actor:               gen.aws_identity(type=IAMUser, userName=snapshot-exfil-user, accountId=ref.account_id)
+  source_ip:           gen.ipv4()
+  user_agent:          "aws-cli/2.15.30 Python/3.11.8 Linux/6.5.0-1018-aws exec-env/CloudShell exe/x86_64.amzn.2 prompt/off"
+  snap_hex:            gen.hex(len=17, case=lower)
+  snapshot_id:         "snap-${ref.snap_hex}"
+  request_uuid:        gen.uuid()
+
+steps:
+  - emit:
+      event_type: aws.cloudtrail@v1
+      fields:
+        eventVersion:       "1.08"
+        eventTime:          gen.timestamp()
+        eventID:            gen.uuid()
+        eventSource:        ec2.amazonaws.com
+        eventName:          ModifySnapshotAttribute
+        eventType:          AwsApiCall
+        eventCategory:      Management
+        awsRegion:          ref.aws_region
+        sourceIPAddress:    ref.source_ip
+        userAgent:          ref.user_agent
+        requestID:          ref.request_uuid
+        requestParameters:
+          snapshotId: ref.snapshot_id
+          createVolumePermission:
+            add:
+              items:
+                - userId: ref.external_account_id
+          attributeType: CREATE_VOLUME_PERMISSION
+        responseElements:
+          requestId: ref.request_uuid
+          _return:   true
+        readOnly:           false
+        managementEvent:    true
+        recipientAccountId: ref.account_id
+        userIdentity:       ref.actor
+        tlsDetails:
+          tlsVersion:               TLSv1.2
+          cipherSuite:              ECDHE-RSA-AES128-GCM-SHA256
+          clientProvidedHostHeader: "ec2.${ref.aws_region}.amazonaws.com"

--- a/scenarios/aws/ec2/share-snapshot-public-group-all.yaml
+++ b/scenarios/aws/ec2/share-snapshot-public-group-all.yaml
@@ -25,7 +25,7 @@ steps:
   - emit:
       event_type: aws.cloudtrail@v1
       fields:
-        eventVersion:       "1.08"
+        eventVersion:       "1.11"
         eventTime:          gen.timestamp()
         eventID:            gen.uuid()
         eventSource:        ec2.amazonaws.com
@@ -51,6 +51,6 @@ steps:
         recipientAccountId: ref.account_id
         userIdentity:       ref.actor
         tlsDetails:
-          tlsVersion:               TLSv1.2
-          cipherSuite:              ECDHE-RSA-AES128-GCM-SHA256
+          tlsVersion:               TLSv1.3
+          cipherSuite:              TLS_AES_128_GCM_SHA256
           clientProvidedHostHeader: "ec2.${ref.aws_region}.amazonaws.com"

--- a/scenarios/aws/ec2/share-snapshot-public-group-all.yaml
+++ b/scenarios/aws/ec2/share-snapshot-public-group-all.yaml
@@ -1,0 +1,56 @@
+type: scenario
+description: |
+  An actor makes an EBS snapshot public by calling ModifySnapshotAttribute with
+  createVolumePermission.add granting create-volume permission to the special group
+  "all". This exposes the snapshot's data to every AWS account, a strictly broader
+  exfiltration scope than sharing with a single named external account. Detections
+  that only inspect the per-account userId in createVolumePermission.add will not
+  observe a group-scoped public share, because a group=all grant carries no userId.
+  See https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifySnapshotAttribute.html
+mitre:
+  tactics: [exfiltration]
+  techniques: [T1537]
+
+state:
+  aws_region:   us-west-2
+  account_id:   "111111111111"
+  actor:        gen.aws_identity(type=IAMUser, userName=snapshot-exfil-user, accountId=ref.account_id)
+  source_ip:    gen.ipv4()
+  user_agent:   "aws-cli/2.15.30 Python/3.11.8 Linux/6.5.0-1018-aws exec-env/CloudShell exe/x86_64.amzn.2 prompt/off"
+  snap_hex:     gen.hex(len=17, case=lower)
+  snapshot_id:  "snap-${ref.snap_hex}"
+  request_uuid: gen.uuid()
+
+steps:
+  - emit:
+      event_type: aws.cloudtrail@v1
+      fields:
+        eventVersion:       "1.08"
+        eventTime:          gen.timestamp()
+        eventID:            gen.uuid()
+        eventSource:        ec2.amazonaws.com
+        eventName:          ModifySnapshotAttribute
+        eventType:          AwsApiCall
+        eventCategory:      Management
+        awsRegion:          ref.aws_region
+        sourceIPAddress:    ref.source_ip
+        userAgent:          ref.user_agent
+        requestID:          ref.request_uuid
+        requestParameters:
+          snapshotId: ref.snapshot_id
+          createVolumePermission:
+            add:
+              items:
+                - group: all
+          attributeType: CREATE_VOLUME_PERMISSION
+        responseElements:
+          requestId: ref.request_uuid
+          _return:   true
+        readOnly:           false
+        managementEvent:    true
+        recipientAccountId: ref.account_id
+        userIdentity:       ref.actor
+        tlsDetails:
+          tlsVersion:               TLSv1.2
+          cipherSuite:              ECDHE-RSA-AES128-GCM-SHA256
+          clientProvidedHostHeader: "ec2.${ref.aws_region}.amazonaws.com"

--- a/scenarios/aws/ec2/share-snapshot-same-account.yaml
+++ b/scenarios/aws/ec2/share-snapshot-same-account.yaml
@@ -1,7 +1,7 @@
 type: scenario
 description: |
   An administrator calls ModifySnapshotAttribute to grant create-volume permission
-  on an EBS snapshot to its own owning account. Because the granted account ID
+  on an EBS snapshot to its owning account. Because the granted account ID
   matches the snapshot owner, this is a benign self-scoped permission change rather
   than an external share, and should not be treated as data exfiltration.
   See https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifySnapshotAttribute.html

--- a/scenarios/aws/ec2/share-snapshot-same-account.yaml
+++ b/scenarios/aws/ec2/share-snapshot-same-account.yaml
@@ -1,0 +1,51 @@
+type: scenario
+description: |
+  An administrator calls ModifySnapshotAttribute to grant create-volume permission
+  on an EBS snapshot to its own owning account. Because the granted account ID
+  matches the snapshot owner, this is a benign self-scoped permission change rather
+  than an external share, and should not be treated as data exfiltration.
+  See https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifySnapshotAttribute.html
+
+state:
+  aws_region:   us-west-2
+  account_id:   "591511666666"
+  actor:        gen.aws_identity(type=AssumedRole, accountId=ref.account_id)
+  source_ip:    gen.ipv4()
+  user_agent:   "aws-cli/2.15.30 Python/3.11.8 Linux/6.5.0-1018-aws exec-env/CloudShell exe/x86_64.amzn.2 prompt/off"
+  snap_hex:     gen.hex(len=17, case=lower)
+  snapshot_id:  "snap-${ref.snap_hex}"
+  request_uuid: gen.uuid()
+
+steps:
+  - emit:
+      event_type: aws.cloudtrail@v1
+      fields:
+        eventVersion:       "1.08"
+        eventTime:          gen.timestamp()
+        eventID:            gen.uuid()
+        eventSource:        ec2.amazonaws.com
+        eventName:          ModifySnapshotAttribute
+        eventType:          AwsApiCall
+        eventCategory:      Management
+        awsRegion:          ref.aws_region
+        sourceIPAddress:    ref.source_ip
+        userAgent:          ref.user_agent
+        requestID:          ref.request_uuid
+        requestParameters:
+          snapshotId: ref.snapshot_id
+          createVolumePermission:
+            add:
+              items:
+                - userId: ref.account_id
+          attributeType: CREATE_VOLUME_PERMISSION
+        responseElements:
+          requestId: ref.request_uuid
+          _return:   true
+        readOnly:           false
+        managementEvent:    true
+        recipientAccountId: ref.account_id
+        userIdentity:       ref.actor
+        tlsDetails:
+          tlsVersion:               TLSv1.2
+          cipherSuite:              ECDHE-RSA-AES128-GCM-SHA256
+          clientProvidedHostHeader: "ec2.${ref.aws_region}.amazonaws.com"

--- a/scenarios/aws/ec2/share-snapshot-same-account.yaml
+++ b/scenarios/aws/ec2/share-snapshot-same-account.yaml
@@ -20,7 +20,7 @@ steps:
   - emit:
       event_type: aws.cloudtrail@v1
       fields:
-        eventVersion:       "1.08"
+        eventVersion:       "1.11"
         eventTime:          gen.timestamp()
         eventID:            gen.uuid()
         eventSource:        ec2.amazonaws.com
@@ -46,6 +46,6 @@ steps:
         recipientAccountId: ref.account_id
         userIdentity:       ref.actor
         tlsDetails:
-          tlsVersion:               TLSv1.2
-          cipherSuite:              ECDHE-RSA-AES128-GCM-SHA256
+          tlsVersion:               TLSv1.3
+          cipherSuite:              TLS_AES_128_GCM_SHA256
           clientProvidedHostHeader: "ec2.${ref.aws_region}.amazonaws.com"


### PR DESCRIPTION
- Add `aws-ec2-snapshot-shared-externally.yaml` validation job covering three scenarios: external account share (attack), public share (attack), and same account share (benign control).
- Add `share-snapshot-external-account.yaml` scenario modeling cross-account EBS snapshot data exfiltration.
- Add `share-snapshot-public-group-all.yaml` scenario for detecting public snapshot sharing.
- Add `share-snapshot-same-account.yaml` scenario representing benign self-scoped permission changes.