### PR TITLE
Add AWS UpdateLoginProfile validation job (T1136.003)

### DIFF
--- a/jobs/splunk/aws/iam/update-login-profile.yaml
+++ b/jobs/splunk/aws/iam/update-login-profile.yaml
@@ -1,0 +1,42 @@
+type: job
+description: |
+  Validation job for AWS UpdateLoginProfile: a principal resets the
+  console password of a different IAM user (privilege escalation via
+  login-profile takeover). Exercises two actor shapes -- a direct IAM
+  user and an assumed-role principal -- both of which the detection's
+  match() check should flag because the acting identity differs from
+  the target userName.
+mitre:
+  tactics: [persistence, privilege-escalation]
+  techniques: [T1136.003]
+
+state:
+  account_id:         "111111111111"
+  aws_region:         us-east-1
+  source_ip:          gen.ipv4()
+  user_agent:         "aws-cli/2.15.30 Python/3.11.8 Linux/5.15.0-101-generic source/x86_64 prompt/off tracemill/1.0"
+  actor_iam_user:     gen.aws_identity(type=IAMUser, userName=attacker-user, accountId=ref.account_id)
+  actor_assumed_role: gen.aws_identity(type=AssumedRole, accountId=ref.account_id)
+
+workloads:
+  - scenario: scenarios/aws/iam/update-login-profile
+    bindings:
+      account_id:  ref.account_id
+      aws_region:  ref.aws_region
+      source_ip:   ref.source_ip
+      user_agent:  ref.user_agent
+      actor:       ref.actor_iam_user
+    expectation:
+      summary: "AWS UpdateLoginProfile -- IAMUser resets the console password of a different IAM user"
+      expected: alert
+
+  - scenario: scenarios/aws/iam/update-login-profile
+    bindings:
+      account_id:  ref.account_id
+      aws_region:  ref.aws_region
+      source_ip:   ref.source_ip
+      user_agent:  ref.user_agent
+      actor:       ref.actor_assumed_role
+    expectation:
+      summary: "AWS UpdateLoginProfile -- AssumedRole principal resets the console password of an IAM user (federated-credential pivot)"
+      expected: alert


### PR DESCRIPTION
- Introduced a validation job to detect privilege escalation via LoginProfile takeover.
- Covered two actor shapes: IAM user and assumed-role principal.
- Included scenarios with flagged expectations for persistence and privilege escalation detection.