### PR TITLE
AWS Bedrock AccessDenied validation job and scenarios (T1078, T1550)

### DIFF
--- a/jobs/splunk/aws/bedrock/aws-bedrock-invoke-model-access-denied.yaml
+++ b/jobs/splunk/aws/bedrock/aws-bedrock-invoke-model-access-denied.yaml
@@ -1,0 +1,42 @@
+type: job
+description: |
+  Validation job for AWS Bedrock Invoke Model Access Denied. Exercises an
+  AccessDenied response to a Bedrock model invocation (InvokeModel), plus two
+  same-permission API variants -- Converse and InvokeModelWithResponseStream
+  -- which AWS records as Bedrock management events gated by the same
+  bedrock:InvokeModel permission.
+
+mitre:
+  tactics: [defense-evasion]
+  techniques: [T1078, T1550]
+
+state:
+  account_id:  "111122223333"
+  aws_region:  us-east-1
+  source_ip:   gen.ipv4()
+
+workloads:
+  - scenario: scenarios/aws/bedrock/invoke-model-access-denied
+    bindings:
+      account_id:  ref.account_id
+      aws_region:  ref.aws_region
+      source_ip:   ref.source_ip
+    expectation:
+      summary: "AWS Bedrock InvokeModel AccessDenied"
+      expected: alert
+  - scenario: scenarios/aws/bedrock/converse-access-denied
+    bindings:
+      account_id:  ref.account_id
+      aws_region:  ref.aws_region
+      source_ip:   ref.source_ip
+    expectation:
+      summary: "AWS Bedrock Converse AccessDenied (same bedrock:InvokeModel permission)"
+      expected: alert
+  - scenario: scenarios/aws/bedrock/invoke-model-stream-access-denied
+    bindings:
+      account_id:  ref.account_id
+      aws_region:  ref.aws_region
+      source_ip:   ref.source_ip
+    expectation:
+      summary: "AWS Bedrock InvokeModelWithResponseStream AccessDenied (same bedrock:InvokeModel permission)"
+      expected: alert

--- a/scenarios/aws/bedrock/converse-access-denied.yaml
+++ b/scenarios/aws/bedrock/converse-access-denied.yaml
@@ -1,0 +1,46 @@
+type: scenario
+description: |
+  Credential access / discovery: an actor using compromised credentials
+  probes Bedrock model access through the Converse API and is rejected
+  with an AccessDenied error. Converse is gated by the same
+  bedrock:InvokeModel permission as the InvokeModel API and is recorded
+  as a Bedrock management event, so an AccessDenied here is the same
+  model-access reconnaissance behavior reached through a different API
+  action.
+mitre:
+  tactics: [defense-evasion]
+  techniques: [T1078, T1550]
+
+state:
+  aws_region:  us-east-1
+  account_id:  "000000000000"
+  user_name:   compromised-user
+  actor:       gen.aws_identity(type=IAMUser, userName=ref.user_name, accountId=ref.account_id)
+  source_ip:   gen.ipv4()
+  user_agent:  "Boto3/1.34.51 md/Botocore#1.34.51 ua/2.0 os/linux#5.15.0-101-generic lang/python#3.11.8 md/pyimpl#CPython cfg/retry-mode#standard md/command#bedrock-runtime.converse Botocore/1.34.51"
+  model_id:    "arn:aws:bedrock:${ref.aws_region}::foundation-model/anthropic.claude-3-5-sonnet-20240620-v1:0"
+
+steps:
+  - emit:
+      event_type: aws.cloudtrail@v1
+      fields:
+        eventVersion:       "1.11"
+        eventTime:          gen.timestamp()
+        eventID:            gen.uuid()
+        eventSource:        bedrock.amazonaws.com
+        eventName:          Converse
+        eventType:          AwsApiCall
+        eventCategory:      Management
+        awsRegion:          ref.aws_region
+        sourceIPAddress:    ref.source_ip
+        userAgent:          ref.user_agent
+        requestID:          gen.uuid()
+        requestParameters:
+          modelId:          ref.model_id
+        responseElements:   null
+        readOnly:           false
+        managementEvent:    true
+        recipientAccountId: ref.account_id
+        userIdentity:       ref.actor
+        errorCode:          AccessDenied
+        errorMessage:       "You don't have access to the model with the specified model ID."

--- a/scenarios/aws/bedrock/invoke-model-access-denied.yaml
+++ b/scenarios/aws/bedrock/invoke-model-access-denied.yaml
@@ -36,7 +36,7 @@ steps:
         requestParameters:
           modelId:          ref.model_id
         responseElements:   null
-        readOnly:           true
+        readOnly:           false
         managementEvent:    true
         recipientAccountId: ref.account_id
         userIdentity:       ref.actor

--- a/scenarios/aws/bedrock/invoke-model-access-denied.yaml
+++ b/scenarios/aws/bedrock/invoke-model-access-denied.yaml
@@ -1,0 +1,44 @@
+type: scenario
+description: |
+  Credential access / discovery: an actor using compromised credentials
+  calls the Bedrock InvokeModel API and is rejected with an AccessDenied
+  error because the principal lacks bedrock:InvokeModel permission on the
+  requested model. Repeated denials of this kind are a reconnaissance
+  signal -- the actor is probing which foundation models the compromised
+  identity can reach before attempting to abuse generative AI resources.
+mitre:
+  tactics: [defense-evasion]
+  techniques: [T1078, T1550]
+
+state:
+  aws_region:  us-east-1
+  account_id:  "000000000000"
+  actor:       gen.aws_identity(type=AssumedRole, accountId=ref.account_id)
+  source_ip:   gen.ipv4()
+  user_agent:  "Boto3/1.34.51 md/Botocore#1.34.51 ua/2.0 os/linux#5.15.0-101-generic lang/python#3.11.8 md/pyimpl#CPython cfg/retry-mode#standard md/command#bedrock-runtime.invoke-model Botocore/1.34.51"
+  model_id:    "arn:aws:bedrock:${ref.aws_region}::foundation-model/anthropic.claude-3-5-sonnet-20240620-v1:0"
+
+steps:
+  - emit:
+      event_type: aws.cloudtrail@v1
+      fields:
+        eventVersion:       "1.11"
+        eventTime:          gen.timestamp()
+        eventID:            gen.uuid()
+        eventSource:        bedrock.amazonaws.com
+        eventName:          InvokeModel
+        eventType:          AwsApiCall
+        eventCategory:      Management
+        awsRegion:          ref.aws_region
+        sourceIPAddress:    ref.source_ip
+        userAgent:          ref.user_agent
+        requestID:          gen.uuid()
+        requestParameters:
+          modelId:          ref.model_id
+        responseElements:   null
+        readOnly:           true
+        managementEvent:    true
+        recipientAccountId: ref.account_id
+        userIdentity:       ref.actor
+        errorCode:          AccessDenied
+        errorMessage:       "You don't have access to the model with the specified model ID."

--- a/scenarios/aws/bedrock/invoke-model-stream-access-denied.yaml
+++ b/scenarios/aws/bedrock/invoke-model-stream-access-denied.yaml
@@ -1,0 +1,46 @@
+type: scenario
+description: |
+  Credential access / discovery: an actor using compromised credentials
+  probes Bedrock model access through the InvokeModelWithResponseStream
+  API and is rejected with an AccessDenied error. The streaming variant
+  is gated by the same bedrock:InvokeModel permission as InvokeModel and
+  is recorded as a Bedrock management event, so an AccessDenied here is
+  the same model-access reconnaissance behavior reached through a
+  different API action.
+mitre:
+  tactics: [defense-evasion]
+  techniques: [T1078, T1550]
+
+state:
+  aws_region:  us-east-1
+  account_id:  "000000000000"
+  user_name:   compromised-user
+  actor:       gen.aws_identity(type=IAMUser, userName=ref.user_name, accountId=ref.account_id)
+  source_ip:   gen.ipv4()
+  user_agent:  "Boto3/1.34.51 md/Botocore#1.34.51 ua/2.0 os/linux#5.15.0-101-generic lang/python#3.11.8 md/pyimpl#CPython cfg/retry-mode#standard md/command#bedrock-runtime.invoke-model-with-response-stream Botocore/1.34.51"
+  model_id:    "arn:aws:bedrock:${ref.aws_region}::foundation-model/anthropic.claude-3-5-sonnet-20240620-v1:0"
+
+steps:
+  - emit:
+      event_type: aws.cloudtrail@v1
+      fields:
+        eventVersion:       "1.11"
+        eventTime:          gen.timestamp()
+        eventID:            gen.uuid()
+        eventSource:        bedrock.amazonaws.com
+        eventName:          InvokeModelWithResponseStream
+        eventType:          AwsApiCall
+        eventCategory:      Management
+        awsRegion:          ref.aws_region
+        sourceIPAddress:    ref.source_ip
+        userAgent:          ref.user_agent
+        requestID:          gen.uuid()
+        requestParameters:
+          modelId:          ref.model_id
+        responseElements:   null
+        readOnly:           false
+        managementEvent:    true
+        recipientAccountId: ref.account_id
+        userIdentity:       ref.actor
+        errorCode:          AccessDenied
+        errorMessage:       "You don't have access to the model with the specified model ID."


### PR DESCRIPTION
- Introduced a validation job testing AccessDenied responses for Bedrock APIs: InvokeModel, Converse, and InvokeModelWithResponseStream.
- Added three scenarios to model model-access reconnaissance events and permission gating via `bedrock:InvokeModel`.