### PR TITLE
Add S3 exfiltration detection jobs for PutBucketReplication (T1537)

### DIFF
--- a/jobs/splunk/aws/s3/aws-exfiltration-via-batch-service.yaml
+++ b/jobs/splunk/aws/s3/aws-exfiltration-via-batch-service.yaml
@@ -1,20 +1,21 @@
 type: job
 description: |
-  Validation job for the "AWS Automated Collection via Batch Service" detection (T1119).
-
-  Exercises the CloudTrail JobCreated service event emitted when an S3 Batch
-  Operations job is created -- the activity adversaries pair with bucket
-  replication to copy objects to an attacker-controlled destination at scale.
-  A legitimate PutBucketReplication workload runs alongside as a benign control
-  to confirm the detection discriminates on the JobCreated event name.
+  S3 Batch Operations job creation recorded as a CloudTrail JobCreated
+  service event (T1119). Adversaries use Batch Operations to copy large
+  volumes of objects to an attacker-controlled destination bucket at scale.
 mitre:
   tactics: [collection]
   techniques: [T1119]
 
+state:
+  account_id: "111122223333"
+  aws_region:  us-east-1
+
 workloads:
   - scenario: scenarios/aws/s3/s3-batch-job-created
+    bindings:
+      account_id: ref.account_id
+      aws_region:  ref.aws_region
     expectation:
       expected: alert
-  - scenario: scenarios/aws/s3/put-bucket-replication
-    expectation:
-      expected: none
+      summary: "S3 Batch Operations JobCreated service event"

--- a/jobs/splunk/aws/s3/aws-exfiltration-via-bucket-replication.yaml
+++ b/jobs/splunk/aws/s3/aws-exfiltration-via-bucket-replication.yaml
@@ -21,6 +21,7 @@ workloads:
       aws_region:  ref.aws_region
       actor:       ref.actor
       source_ip:   ref.source_ip
+      dest_bucket: ref.dest_bucket
     expectation:
       expected: alert
       summary: "PutBucketReplication to destination bucket"

--- a/jobs/splunk/aws/s3/aws-exfiltration-via-bucket-replication.yaml
+++ b/jobs/splunk/aws/s3/aws-exfiltration-via-bucket-replication.yaml
@@ -1,0 +1,26 @@
+type: job
+description: |
+  Exercises PutBucketReplication (T1537) -- an adversary configures S3 bucket
+  replication to silently copy objects to an attacker-controlled destination
+  bucket. Validates that the detection fires on any PutBucketReplication call.
+mitre:
+  tactics: [exfiltration]
+  techniques: [T1537]
+
+state:
+  account_id: "111122223333"
+  aws_region:  us-east-1
+  actor:       gen.aws_identity(type=AssumedRole, accountId=ref.account_id)
+  source_ip:   gen.ipv4()
+  dest_bucket: exfiltration-bucket
+
+workloads:
+  - scenario: scenarios/aws/s3/put-bucket-replication
+    bindings:
+      account_id: ref.account_id
+      aws_region:  ref.aws_region
+      actor:       ref.actor
+      source_ip:   ref.source_ip
+    expectation:
+      expected: alert
+      summary: "PutBucketReplication to destination bucket"


### PR DESCRIPTION
- Introduced a validation job for detecting S3 bucket replication misuse (T1537).
- Removed accidenatly added benign S3 bucket replication workload in a sibling job