### PR TITLE
Add IAM CreatePolicyVersion privilege-escalation (T1078.004)

### DIFF
--- a/jobs/splunk/aws/iam/aws-create-policy-version-to-allow-all-resources.yaml
+++ b/jobs/splunk/aws/iam/aws-create-policy-version-to-allow-all-resources.yaml
@@ -1,0 +1,30 @@
+type: job
+description: |
+  IAM CreatePolicyVersion privilege escalation (T1078.004). Three workloads:
+  an attack-positive granting Action "*" on Resource "*", a benign failed
+  scoped-wildcard control, and a NotAction-wildcard variant that grants
+  all-actions-except-IAM -- an evasion of Action-only policy inspection.
+
+mitre:
+  tactics: [privilege-escalation, persistence]
+  techniques: ["T1078.004"]
+
+workloads:
+  - scenario: scenarios/aws/iam/policy-version-allow-all-actions
+    expectation:
+      expected: alert
+      summary: "IAM CreatePolicyVersion granting Action '*' on Resource '*' -- unrestricted access"
+      mitre:
+        tactics: [privilege-escalation, persistence]
+        techniques: ["T1078.004"]
+  - scenario: scenarios/aws/iam/policy-version-create-denied
+    expectation:
+      expected: none
+      summary: "Failed CreatePolicyVersion (NoSuchEntity) on a scoped iam:* document -- must not fire"
+  - scenario: scenarios/aws/iam/policy-version-not-action-wildcard
+    expectation:
+      expected: alert
+      summary: "IAM CreatePolicyVersion using NotAction iam:* on Resource '*' -- all-actions-except-IAM, an Action-filter evasion"
+      mitre:
+        tactics: [privilege-escalation, persistence]
+        techniques: ["T1078.004"]

--- a/scenarios/aws/iam/policy-version-allow-all-actions.yaml
+++ b/scenarios/aws/iam/policy-version-allow-all-actions.yaml
@@ -1,0 +1,55 @@
+type: scenario
+description: |
+  Privilege escalation: a new default IAM policy version grants Action "*" on
+  Resource "*", conferring unrestricted access.
+mitre:
+  tactics: [privilege-escalation, persistence]
+  techniques: [T1078.004]
+
+state:
+  aws_region:  us-east-1
+  account_id:  "000000000000"
+  actor:       gen.aws_identity(type=IAMUser, userName=attacker-user, accountId=ref.account_id)
+  source_ip:   gen.ipv4()
+  user_agent:  "aws-cli/2.31.27 md/awscrt#0.27.6 ua/2.1 os/linux md/arch#x86_64 lang/python#3.13.9 cfg/retry-mode#standard md/command#iam.create-policy-version"
+  tls_version: "TLSv1.3"
+  tls_cipher:  TLS_AES_128_GCM_SHA256
+  policy_name: escalation-policy
+  policy_arn:  "arn:aws:iam::${ref.account_id}:policy/${ref.policy_name}"
+  # JSON policy document delivered as a compact string, exactly as CloudTrail
+  # records an aws-cli submission. The single Allow statement grants Action "*"
+  # on Resource "*".
+  policy_document: "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"AllowEverything\",\"Effect\":\"Allow\",\"Action\":\"*\",\"Resource\":\"*\"}]}"
+
+steps:
+  - emit:
+      event_type: aws.cloudtrail@v1
+      fields:
+        eventVersion:       "1.11"
+        eventTime:          gen.timestamp()
+        eventID:            gen.uuid()
+        eventSource:        iam.amazonaws.com
+        eventName:          CreatePolicyVersion
+        eventType:          AwsApiCall
+        eventCategory:      Management
+        awsRegion:          ref.aws_region
+        sourceIPAddress:    ref.source_ip
+        userAgent:          ref.user_agent
+        requestID:          gen.uuid()
+        requestParameters:
+          policyArn:     ref.policy_arn
+          policyDocument: ref.policy_document
+          setAsDefault:  true
+        responseElements:
+          policyVersion:
+            versionId:        v2
+            isDefaultVersion: true
+            createDate:       gen.timestamp(format="Jan 2, 2006, 3:04:05 PM")
+        readOnly:           false
+        managementEvent:    true
+        recipientAccountId: ref.account_id
+        userIdentity:       ref.actor
+        tlsDetails:
+          tlsVersion:               ref.tls_version
+          cipherSuite:              ref.tls_cipher
+          clientProvidedHostHeader: iam.amazonaws.com

--- a/scenarios/aws/iam/policy-version-create-denied.yaml
+++ b/scenarios/aws/iam/policy-version-create-denied.yaml
@@ -1,0 +1,51 @@
+type: scenario
+description: |
+  Benign control: a CreatePolicyVersion call fails with NoSuchEntity (target
+  policy absent). The scoped iam:* document never takes effect, so it must not
+  be treated as a grant of access to all resources.
+
+state:
+  aws_region:  us-east-1
+  account_id:  "000000000000"
+  actor:       gen.aws_identity(type=IAMUser, userName=ops-engineer, accountId=ref.account_id)
+  source_ip:   gen.ipv4()
+  user_agent:  "aws-cli/2.31.27 md/awscrt#0.27.6 ua/2.1 os/linux md/arch#x86_64 lang/python#3.13.9 cfg/retry-mode#standard md/command#iam.create-policy-version"
+  tls_version: "TLSv1.3"
+  tls_cipher:  TLS_AES_128_GCM_SHA256
+  policy_name: missing-policy
+  policy_arn:  "arn:aws:iam::${ref.account_id}:policy/${ref.policy_name}"
+  error_message: "Policy ${ref.policy_arn} does not exist or is not attachable."
+  # Scoped wildcard (iam:*), not Action "*"; and the call fails anyway. Compact
+  # JSON string, exactly as CloudTrail records an aws-cli submission.
+  policy_document: "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"AllowEverything\",\"Effect\":\"Allow\",\"Action\":\"iam:*\",\"Resource\":\"*\"}]}"
+
+steps:
+  - emit:
+      event_type: aws.cloudtrail@v1
+      fields:
+        eventVersion:       "1.11"
+        eventTime:          gen.timestamp()
+        eventID:            gen.uuid()
+        eventSource:        iam.amazonaws.com
+        eventName:          CreatePolicyVersion
+        eventType:          AwsApiCall
+        eventCategory:      Management
+        awsRegion:          ref.aws_region
+        sourceIPAddress:    ref.source_ip
+        userAgent:          ref.user_agent
+        requestID:          gen.uuid()
+        errorCode:          NoSuchEntityException
+        errorMessage:       ref.error_message
+        requestParameters:
+          policyArn:     ref.policy_arn
+          policyDocument: ref.policy_document
+          setAsDefault:  true
+        responseElements:   null
+        readOnly:           false
+        managementEvent:    true
+        recipientAccountId: ref.account_id
+        userIdentity:       ref.actor
+        tlsDetails:
+          tlsVersion:               ref.tls_version
+          cipherSuite:              ref.tls_cipher
+          clientProvidedHostHeader: iam.amazonaws.com

--- a/scenarios/aws/iam/policy-version-not-action-wildcard.yaml
+++ b/scenarios/aws/iam/policy-version-not-action-wildcard.yaml
@@ -1,0 +1,56 @@
+type: scenario
+description: |
+  Privilege escalation: a new default IAM policy version uses NotAction iam:*
+  on Resource "*", granting every action except IAM on every resource --
+  unrestricted access without ever naming Action "*".
+mitre:
+  tactics: [privilege-escalation, persistence]
+  techniques: [T1078.004]
+
+state:
+  aws_region:  us-east-1
+  account_id:  "000000000000"
+  actor:       gen.aws_identity(type=IAMUser, userName=attacker-user, accountId=ref.account_id)
+  source_ip:   gen.ipv4()
+  user_agent:  "aws-cli/2.31.27 md/awscrt#0.27.6 ua/2.1 os/linux md/arch#x86_64 lang/python#3.13.9 cfg/retry-mode#standard md/command#iam.create-policy-version"
+  policy_name: escalation-policy
+  policy_arn:  "arn:aws:iam::${ref.account_id}:policy/${ref.policy_name}"
+  tls_version: "TLSv1.3"
+  tls_cipher:  TLS_AES_128_GCM_SHA256
+  # Allow with NotAction iam:* over Resource "*" -- grants all-actions-except-IAM
+  # on every resource. The literal Action element is absent by design. Compact
+  # JSON string, exactly as CloudTrail records an aws-cli submission.
+  policy_document: "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"AllowAllExceptIam\",\"Effect\":\"Allow\",\"NotAction\":\"iam:*\",\"Resource\":\"*\"}]}"
+
+steps:
+  - emit:
+      event_type: aws.cloudtrail@v1
+      fields:
+        eventVersion:       "1.11"
+        eventTime:          gen.timestamp()
+        eventID:            gen.uuid()
+        eventSource:        iam.amazonaws.com
+        eventName:          CreatePolicyVersion
+        eventType:          AwsApiCall
+        eventCategory:      Management
+        awsRegion:          ref.aws_region
+        sourceIPAddress:    ref.source_ip
+        userAgent:          ref.user_agent
+        requestID:          gen.uuid()
+        requestParameters:
+          policyArn:     ref.policy_arn
+          policyDocument: ref.policy_document
+          setAsDefault:  true
+        responseElements:
+          policyVersion:
+            versionId:        v2
+            isDefaultVersion: true
+            createDate:       gen.timestamp(format="Jan 2, 2006, 3:04:05 PM")
+        readOnly:           false
+        managementEvent:    true
+        recipientAccountId: ref.account_id
+        userIdentity:       ref.actor
+        tlsDetails:
+          tlsVersion:               ref.tls_version
+          cipherSuite:              ref.tls_cipher
+          clientProvidedHostHeader: iam.amazonaws.com


### PR DESCRIPTION
Adds tracemill library coverage for the "AWS Create Policy Version to allow all resources" detection (T1078.004):

- 3 scenarios under scenarios/aws/iam/: an attack-positive (Action "*" on Resource "*"), a benign failed-call control (NoSuchEntity on a scoped iam:* document), and a NotAction-wildcard variant that grants all-actions-except-IAM -- a detection-gap evasion the analytic does not inspect.
- A validation job under jobs/splunk/aws/iam/ with top-level + per-workload MITRE tagging and summaries.