### PR TITLE
Add AWS ConsoleLogin failed-password validation (T1110.001)

### DIFF
--- a/jobs/splunk/aws/signin/aws-credential-access-failed-login.yaml
+++ b/jobs/splunk/aws/signin/aws-credential-access-failed-login.yaml
@@ -1,0 +1,29 @@
+type: job
+description: |
+  Exercises a failed AWS Management Console password sign-in (CloudTrail
+  ConsoleLogin, errorMessage "Failed authentication", MFAUsed "No"). Models a
+  password guessing / brute-force attempt against a console identity. MITRE
+  ATT&CK T1110.001.
+
+mitre:
+  tactics: [credential-access]
+  techniques: [T1110.001]
+
+state:
+  account_id: "111111111111"
+  aws_region: us-east-1
+  source_ip:  gen.ipv4()
+  user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 tracemill/1.0"
+  actor:      gen.aws_identity(type=IAMUser, userName=attacker-user, accountId=ref.account_id)
+
+workloads:
+  - scenario: scenarios/aws/signin/console-login-failed-auth
+    bindings:
+      account_id: ref.account_id
+      aws_region: ref.aws_region
+      source_ip:  ref.source_ip
+      user_agent: ref.user_agent
+      actor:      ref.actor
+    expectation:
+      summary: "AWS ConsoleLogin -- console sign-in fails password authentication (Failed authentication, MFAUsed No)"
+      expected: alert

--- a/scenarios/aws/signin/console-login-failed-auth.yaml
+++ b/scenarios/aws/signin/console-login-failed-auth.yaml
@@ -1,0 +1,51 @@
+type: scenario
+description: |
+  Credential access: an AWS Management Console sign-in fails password
+  authentication. The supplied user name exists but the password was
+  rejected (CloudTrail ConsoleLogin with errorMessage "Failed
+  authentication" and a "Failure" result), with no MFA step involved.
+
+mitre:
+  tactics: [credential-access]
+  techniques: [T1110.001]
+
+state:
+  aws_region:  us-east-1
+  account_id:  "000000000000"
+  actor:       gen.aws_identity(type=IAMUser, userName=attacker-user, accountId=ref.account_id)
+  source_ip:   gen.ipv4()
+  user_agent:  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 tracemill/1.0"
+  login_to:    "https://us-east-1.console.aws.amazon.com/console/home?hashArgs=%23&isauthcode=true&region=us-east-1&state=hashArgs%23"
+  tls_version: "TLSv1.2"
+  tls_cipher:  ECDHE-RSA-AES128-GCM-SHA256
+
+steps:
+  - emit:
+      event_type: aws.cloudtrail@v1
+      fields:
+        eventVersion:       "1.08"
+        eventTime:          gen.timestamp()
+        eventID:            gen.uuid()
+        eventSource:        signin.amazonaws.com
+        eventName:          ConsoleLogin
+        eventType:          AwsConsoleSignIn
+        eventCategory:      Management
+        awsRegion:          ref.aws_region
+        sourceIPAddress:    ref.source_ip
+        userAgent:          ref.user_agent
+        errorMessage:       "Failed authentication"
+        requestParameters:  null
+        responseElements:
+          ConsoleLogin: "Failure"
+        additionalEventData:
+          LoginTo:       ref.login_to
+          MobileVersion: "No"
+          MFAUsed:       "No"
+        readOnly:           false
+        managementEvent:    true
+        recipientAccountId: ref.account_id
+        userIdentity:       ref.actor
+        tlsDetails:
+          tlsVersion:               ref.tls_version
+          cipherSuite:              ref.tls_cipher
+          clientProvidedHostHeader: "signin.aws.amazon.com"


### PR DESCRIPTION
- Introduced validation job `aws-credential-access-failed-login.yaml` modeling password brute-force attempts without MFA.
- Added scenario `console-login-failed-auth.yaml` to simulate CloudTrail ConsoleLogin events with failed authentication.
- Both include MITRE ATT&CK credential-access coverage for technique T1110.001.