### PR TITLE
Add RDS master password reset detection and control scenarios (T1110)

### DIFF
--- a/jobs/splunk/aws/rds/aws-credential-access-rds-password-reset.yaml
+++ b/jobs/splunk/aws/rds/aws-credential-access-rds-password-reset.yaml
@@ -1,0 +1,48 @@
+type: job
+description: |
+  RDS master credential access (MITRE T1110): resets the master user password
+  of an Amazon RDS DB instance via ModifyDBInstance, the action a detection
+  keyed on the masterUserPassword request parameter is meant to catch. Pairs the
+  attack with a same-API control that should not alert -- a Secrets-Manager-managed
+  credential rotation (RotateMasterUserPassword), which mints a new random secret
+  the caller never learns and so is not a reset-to-known-value.
+  API: https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_ModifyDBInstance.html
+
+mitre:
+  tactics: [credential-access]
+  techniques: [T1110]
+
+state:
+  aws_region:     us-east-1
+  account_id:     "000000000000"
+  source_ip:      gen.ipv4()
+  user_agent:     "Boto3/1.34.51 Python/3.11.8 Linux/5.15.0-101-generic Botocore/1.34.51 tracemill/1.0"
+  actor:          gen.aws_identity(type=AssumedRole, accountId=ref.account_id)
+  db_instance_id: database-1
+
+workloads:
+  - scenario: scenarios/aws/rds/reset-rds-master-password
+    bindings:
+      aws_region:     ref.aws_region
+      account_id:     ref.account_id
+      source_ip:      ref.source_ip
+      user_agent:     ref.user_agent
+      actor:          ref.actor
+      db_instance_id: ref.db_instance_id
+    expectation:
+      expected: alert
+      summary: "RDS master password reset via ModifyDBInstance (masterUserPassword supplied)"
+      mitre:
+        tactics: [credential-access]
+        techniques: [T1110]
+  - scenario: scenarios/aws/rds/rotate-master-user-password
+    bindings:
+      aws_region:     ref.aws_region
+      account_id:     ref.account_id
+      source_ip:      ref.source_ip
+      user_agent:     ref.user_agent
+      actor:          ref.actor
+      db_instance_id: ref.db_instance_id
+    expectation:
+      expected: none
+      summary: "Secrets-Manager master credential rotation (RotateMasterUserPassword) -- benign control, no masterUserPassword"

--- a/jobs/splunk/aws/rds/aws-credential-access-rds-password-reset.yaml
+++ b/jobs/splunk/aws/rds/aws-credential-access-rds-password-reset.yaml
@@ -14,7 +14,7 @@ mitre:
 
 state:
   aws_region:     us-east-1
-  account_id:     "000000000000"
+  account_id:     "111122223333"
   source_ip:      gen.ipv4()
   user_agent:     "Boto3/1.34.51 Python/3.11.8 Linux/5.15.0-101-generic Botocore/1.34.51 tracemill/1.0"
   actor:          gen.aws_identity(type=AssumedRole, accountId=ref.account_id)

--- a/scenarios/aws/rds/reset-rds-master-password.yaml
+++ b/scenarios/aws/rds/reset-rds-master-password.yaml
@@ -1,0 +1,66 @@
+type: scenario
+description: |
+  Credential access: an actor operating with assumed-role credentials resets
+  the master user password of an Amazon RDS DB instance via ModifyDBInstance,
+  supplying a new masterUserPassword that takes effect immediately.
+mitre:
+  tactics: [credential-access]
+  techniques: [T1110]
+
+state:
+  aws_region:      us-east-1
+  account_id:      "000000000000"
+  actor:           gen.aws_identity(type=AssumedRole, accountId=ref.account_id)
+  source_ip:       gen.ipv4()
+  user_agent:      "Boto3/1.34.51 Python/3.11.8 Linux/5.15.0-101-generic Botocore/1.34.51 tracemill/1.0"
+  db_instance_id:  database-1
+  db_instance_arn: "arn:aws:rds:${ref.aws_region}:${ref.account_id}:db:${ref.db_instance_id}"
+
+steps:
+  - emit:
+      event_type: aws.cloudtrail@v1
+      fields:
+        eventVersion:    "1.08"
+        eventTime:       gen.timestamp()
+        eventID:         gen.uuid()
+        eventSource:     rds.amazonaws.com
+        eventName:       ModifyDBInstance
+        eventType:       AwsApiCall
+        eventCategory:   Management
+        awsRegion:       ref.aws_region
+        sourceIPAddress: ref.source_ip
+        userAgent:       ref.user_agent
+        requestID:       gen.uuid()
+        requestParameters:
+          dBInstanceIdentifier:    ref.db_instance_id
+          applyImmediately:        true
+          masterUserPassword:      "****"
+          allowMajorVersionUpgrade: false
+          deletionProtection:      true
+        responseElements:
+          dBInstanceIdentifier:           ref.db_instance_id
+          dBInstanceArn:                  ref.db_instance_arn
+          dBInstanceClass:                db.m5.large
+          dBInstanceStatus:               available
+          engine:                         postgres
+          engineVersion:                  "15.4"
+          masterUsername:                 admin
+          allocatedStorage:               100
+          backupRetentionPeriod:          7
+          multiAZ:                        false
+          publiclyAccessible:             false
+          storageType:                    gp3
+          storageEncrypted:               true
+          iAMDatabaseAuthenticationEnabled: false
+          deletionProtection:             true
+          pendingModifiedValues:
+            masterUserPassword: "****"
+        readOnly:                     false
+        managementEvent:              true
+        recipientAccountId:           ref.account_id
+        sessionCredentialFromConsole: "false"
+        userIdentity:                 ref.actor
+        tlsDetails:
+          tlsVersion:               "TLSv1.2"
+          cipherSuite:              "ECDHE-RSA-AES128-GCM-SHA256"
+          clientProvidedHostHeader: "rds.${ref.aws_region}.amazonaws.com"

--- a/scenarios/aws/rds/rotate-master-user-password.yaml
+++ b/scenarios/aws/rds/rotate-master-user-password.yaml
@@ -1,0 +1,70 @@
+type: scenario
+description: |
+  Control variant: an administrator rotates the Amazon RDS master user
+  credential that is managed in AWS Secrets Manager, via ModifyDBInstance with
+  RotateMasterUserPassword set to true. Rotation mints a new random password
+  into the managed secret -- the caller does not receive the new password in
+  the API response and would need a separate Secrets Manager read to use it.
+  Because the request carries no masterUserPassword parameter, a detection
+  keyed on that parameter does not (and should not) fire on rotation. This
+  variant exercises that boundary: a credential-management call on the same API
+  that is distinct from resetting the password to a caller-chosen value.
+
+state:
+  aws_region:      us-east-1
+  account_id:      "000000000000"
+  actor:           gen.aws_identity(type=AssumedRole, accountId=ref.account_id)
+  source_ip:       gen.ipv4()
+  user_agent:      "Boto3/1.34.51 Python/3.11.8 Linux/5.15.0-101-generic Botocore/1.34.51 tracemill/1.0"
+  db_instance_id:  database-1
+  db_instance_arn: "arn:aws:rds:${ref.aws_region}:${ref.account_id}:db:${ref.db_instance_id}"
+  secret_id:       gen.uuid()
+  secret_arn:      "arn:aws:secretsmanager:${ref.aws_region}:${ref.account_id}:secret:rds!db-${ref.secret_id}"
+
+steps:
+  - emit:
+      event_type: aws.cloudtrail@v1
+      fields:
+        eventVersion:    "1.08"
+        eventTime:       gen.timestamp()
+        eventID:         gen.uuid()
+        eventSource:     rds.amazonaws.com
+        eventName:       ModifyDBInstance
+        eventType:       AwsApiCall
+        eventCategory:   Management
+        awsRegion:       ref.aws_region
+        sourceIPAddress: ref.source_ip
+        userAgent:       ref.user_agent
+        requestID:       gen.uuid()
+        requestParameters:
+          dBInstanceIdentifier:      ref.db_instance_id
+          applyImmediately:          true
+          rotateMasterUserPassword:  true
+        responseElements:
+          dBInstanceIdentifier:           ref.db_instance_id
+          dBInstanceArn:                  ref.db_instance_arn
+          dBInstanceClass:                db.m5.large
+          dBInstanceStatus:               available
+          engine:                         postgres
+          engineVersion:                  "15.4"
+          masterUsername:                 admin
+          allocatedStorage:               100
+          backupRetentionPeriod:          7
+          multiAZ:                        false
+          publiclyAccessible:             false
+          storageType:                    gp3
+          storageEncrypted:               true
+          iAMDatabaseAuthenticationEnabled: false
+          masterUserSecret:
+            secretArn:     ref.secret_arn
+            secretStatus:  rotating
+            kmsKeyId:      "arn:aws:kms:${ref.aws_region}:${ref.account_id}:key/aws/secretsmanager"
+        readOnly:                     false
+        managementEvent:              true
+        recipientAccountId:           ref.account_id
+        sessionCredentialFromConsole: "false"
+        userIdentity:                 ref.actor
+        tlsDetails:
+          tlsVersion:               "TLSv1.2"
+          cipherSuite:              "ECDHE-RSA-AES128-GCM-SHA256"
+          clientProvidedHostHeader: "rds.${ref.aws_region}.amazonaws.com"


### PR DESCRIPTION
- Added validation job `aws-credential-access-rds-password-reset.yaml` to detect Amazon RDS master password resets via `ModifyDBInstance` API.
- Introduced `reset-rds-master-password.yaml` scenario to simulate an explicit password reset attack with `masterUserPassword` supplied.
- Added `rotate-master-user-password.yaml` control scenario to model benign credential rotation without triggering detection.
- Both scenarios include MITRE ATT&CK credential-access coverage for technique T1110.