### PR TITLE
Add detection for CloudWatch Logs log group deletion (T1562.008)

### DIFF
--- a/jobs/splunk/aws/logs/aws-defense-evasion-delete-cloudwatch-log-group.yaml
+++ b/jobs/splunk/aws/logs/aws-defense-evasion-delete-cloudwatch-log-group.yaml
@@ -1,0 +1,49 @@
+type: job
+description: |
+  Actor deletes a CloudWatch Logs log group, destroying archived log events
+  and impairing audit logging (T1562.008). Reuses one deletion scenario across
+  two workloads that differ only in request transport: the attack workload
+  issues the call over the CLI and is expected to alert, while the control
+  workload issues an identical deletion from the AWS Management Console -- the
+  one field the detection's console exclusion keys on -- and must not fire.
+  API: https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_DeleteLogGroup.html
+
+mitre:
+  tactics: [defense-evasion]
+  techniques: [T1562.008]
+
+state:
+  aws_region:         us-west-2
+  account_id:         "111111111111"
+  source_ip:          gen.ipv4()
+  actor:              gen.aws_identity(type=IAMUser, userName=attacker-cli, accountId=ref.account_id)
+  log_group_name:     test-logs
+  cli_user_agent:     "aws-cli/2.7.3 Python/3.9.13 Darwin/21.5.0 source/x86_64 prompt/off command/logs.delete-log-group tracemill/1.0"
+  console_user_agent: console.amazonaws.com
+
+workloads:
+  - scenario: scenarios/aws/logs/delete-log-group
+    bindings:
+      aws_region:     ref.aws_region
+      account_id:     ref.account_id
+      source_ip:      ref.source_ip
+      actor:          ref.actor
+      log_group_name: ref.log_group_name
+      user_agent:     ref.cli_user_agent
+    expectation:
+      expected: alert
+      summary: "CloudWatch Logs log group deleted over the CLI"
+      mitre:
+        tactics: [defense-evasion]
+        techniques: [T1562.008]
+  - scenario: scenarios/aws/logs/delete-log-group
+    bindings:
+      aws_region:     ref.aws_region
+      account_id:     ref.account_id
+      source_ip:      ref.source_ip
+      actor:          ref.actor
+      log_group_name: ref.log_group_name
+      user_agent:     ref.console_user_agent
+    expectation:
+      expected: none
+      summary: "Identical deletion issued from the AWS Management Console (benign control)"

--- a/scenarios/aws/logs/delete-log-group.yaml
+++ b/scenarios/aws/logs/delete-log-group.yaml
@@ -1,0 +1,46 @@
+type: scenario
+description: |
+  Defense evasion: actor deletes a CloudWatch Logs log group, permanently
+  destroying all archived log events it held and breaking the audit trail
+  for the monitored resources.
+mitre:
+  tactics: [defense-evasion]
+  techniques: [T1562.008]
+
+state:
+  aws_region:     us-west-2
+  account_id:     "111111111111"
+  actor:          gen.aws_identity(type=IAMUser, userName=attacker-cli, accountId=ref.account_id)
+  source_ip:      gen.ipv4()
+  user_agent:     "aws-cli/2.7.3 Python/3.9.13 Darwin/21.5.0 source/x86_64 prompt/off command/logs.delete-log-group tracemill/1.0"
+  tls_version:    "TLSv1.2"
+  tls_cipher:     ECDHE-RSA-AES128-GCM-SHA256
+  log_group_name: test-logs
+
+steps:
+  - emit:
+      event_type: aws.cloudtrail@v1
+      fields:
+        eventVersion:       "1.08"
+        eventTime:          gen.timestamp()
+        eventID:            gen.uuid()
+        eventSource:        logs.amazonaws.com
+        eventName:          DeleteLogGroup
+        eventType:          AwsApiCall
+        eventCategory:      Management
+        apiVersion:         "20140328"
+        awsRegion:          ref.aws_region
+        sourceIPAddress:    ref.source_ip
+        userAgent:          ref.user_agent
+        requestID:          gen.uuid()
+        requestParameters:
+          logGroupName: ref.log_group_name
+        responseElements:   null
+        readOnly:           false
+        managementEvent:    true
+        recipientAccountId: ref.account_id
+        userIdentity:       ref.actor
+        tlsDetails:
+          tlsVersion:               ref.tls_version
+          cipherSuite:              ref.tls_cipher
+          clientProvidedHostHeader: "logs.${ref.aws_region}.amazonaws.com"


### PR DESCRIPTION
- Introduced `aws-defense-evasion-delete-cloudwatch-log-group.yaml` validation job to detect log group deletions impairing audit logging via the `DeleteLogGroup` API.
- Added `delete-log-group.yaml` scenario modeling malicious deletion and benign control executions.
- Includes MITRE ATT&CK defense-evasion coverage for technique T1562.008.