### PR TITLE
Add detection for disabling CloudTrail logging (T1562.008)

### DIFF
--- a/jobs/splunk/aws/cloudtrail/aws-defense-evasion-stop-logging-cloudtrail.yaml
+++ b/jobs/splunk/aws/cloudtrail/aws-defense-evasion-stop-logging-cloudtrail.yaml
@@ -1,0 +1,29 @@
+type: job
+description: |
+  Actor calls StopLogging to suspend recording of API activity and log-file
+  delivery for a CloudTrail trail, blinding downstream detection.
+
+mitre:
+  tactics: [defense-evasion]
+  techniques: [T1562.008]
+
+state:
+  account_id: "111111111111"
+  aws_region: us-west-2
+  source_ip:  gen.ipv4()
+  user_agent: "aws-cli/2.15.30 Python/3.11.8 Darwin/23.4.0 source/x86_64 command/cloudtrail.stop-logging"
+  actor:      gen.aws_identity(type=IAMUser, accountId=ref.account_id)
+  trail_name: production-trail
+
+workloads:
+  - scenario: scenarios/aws/cloudtrail/stop-logging
+    bindings:
+      account_id: ref.account_id
+      aws_region: ref.aws_region
+      source_ip:  ref.source_ip
+      user_agent: ref.user_agent
+      actor:      ref.actor
+      trail_name: ref.trail_name
+    expectation:
+      summary: AWS Defense Evasion Stop Logging Cloudtrail
+      expected: alert

--- a/scenarios/aws/cloudtrail/stop-logging.yaml
+++ b/scenarios/aws/cloudtrail/stop-logging.yaml
@@ -1,0 +1,45 @@
+type: scenario
+description: |
+  Defense evasion: actor calls StopLogging to suspend recording of API
+  activity and log-file delivery for a CloudTrail trail, blinding
+  downstream detection while remaining in the environment.
+mitre:
+  tactics: [defense-evasion]
+  techniques: [T1562.008]
+
+state:
+  aws_region:  us-west-2
+  account_id:  "000000000000"
+  actor:       gen.aws_identity(type=IAMUser, accountId=ref.account_id)
+  source_ip:   gen.ipv4()
+  user_agent:  "aws-cli/2.15.30 Python/3.11.8 Darwin/23.4.0 source/x86_64 command/cloudtrail.stop-logging"
+  tls_version: "TLSv1.2"
+  tls_cipher:  ECDHE-RSA-AES128-GCM-SHA256
+  trail_name:  production-trail
+
+steps:
+  - emit:
+      event_type: aws.cloudtrail@v1
+      fields:
+        eventVersion:       "1.08"
+        eventTime:          gen.timestamp()
+        eventID:            gen.uuid()
+        eventSource:        cloudtrail.amazonaws.com
+        eventName:          StopLogging
+        eventType:          AwsApiCall
+        eventCategory:      Management
+        awsRegion:          ref.aws_region
+        sourceIPAddress:    ref.source_ip
+        userAgent:          ref.user_agent
+        requestID:          gen.uuid()
+        requestParameters:
+          name: ref.trail_name
+        responseElements:   null
+        readOnly:           false
+        managementEvent:    true
+        recipientAccountId: ref.account_id
+        userIdentity:       ref.actor
+        tlsDetails:
+          tlsVersion:               ref.tls_version
+          cipherSuite:              ref.tls_cipher
+          clientProvidedHostHeader: "cloudtrail.${ref.aws_region}.amazonaws.com"


### PR DESCRIPTION
- Introduced `aws-defense-evasion-stop-logging-cloudtrail.yaml` validation job to detect use of the `StopLogging` API for disabling CloudTrail logging.
- Added `stop-logging.yaml` scenario modeling malicious activity.
- Includes MITRE ATT&CK defense-evasion coverage for technique T1562.008.