### PR TITLE
Add detection for CloudTrail UpdateTrail defense evasion (T1562.008)

### DIFF
--- a/jobs/splunk/aws/cloudtrail/aws-defense-evasion-update-cloudtrail.yaml
+++ b/jobs/splunk/aws/cloudtrail/aws-defense-evasion-update-cloudtrail.yaml
@@ -1,0 +1,29 @@
+type: job
+description: |
+  Actor calls UpdateTrail to modify the settings of an existing CloudTrail
+  trail, degrading logging visibility (defense evasion, T1562.008).
+
+mitre:
+  tactics: [defense-evasion]
+  techniques: [T1562.008]
+
+state:
+  account_id: "111111111111"
+  aws_region: us-west-2
+  source_ip:  gen.ipv4()
+  user_agent: "aws-cli/2.15.30 Python/3.11.8 Darwin/23.4.0 source/x86_64 prompt/off command/cloudtrail.update-trail tracemill/1.0"
+  actor:      gen.aws_identity(type=IAMUser, accountId=ref.account_id)
+  trail_name: production-trail
+
+workloads:
+  - scenario: scenarios/aws/cloudtrail/update-trail
+    bindings:
+      account_id: ref.account_id
+      aws_region: ref.aws_region
+      source_ip:  ref.source_ip
+      user_agent: ref.user_agent
+      actor:      ref.actor
+      trail_name: ref.trail_name
+    expectation:
+      summary: AWS Defense Evasion Update Cloudtrail
+      expected: alert

--- a/scenarios/aws/cloudtrail/update-trail.yaml
+++ b/scenarios/aws/cloudtrail/update-trail.yaml
@@ -1,0 +1,57 @@
+type: scenario
+description: |
+  Defense evasion: actor calls UpdateTrail to modify the settings of an
+  existing CloudTrail trail. Changing trail configuration can reduce
+  logging coverage or redirect log delivery, degrading visibility into
+  API activity while the actor remains in the environment.
+mitre:
+  tactics: [defense-evasion]
+  techniques: [T1562.008]
+
+state:
+  aws_region:  us-west-2
+  account_id:  "000000000000"
+  actor:       gen.aws_identity(type=IAMUser, accountId=ref.account_id)
+  source_ip:   gen.ipv4()
+  user_agent:  "aws-cli/2.15.30 Python/3.11.8 Darwin/23.4.0 source/x86_64 prompt/off command/cloudtrail.update-trail"
+  tls_version: "TLSv1.2"
+  tls_cipher:  ECDHE-RSA-AES128-GCM-SHA256
+  trail_name:  production-trail
+  s3_bucket:   org-cloudtrail-logs
+  trail_arn:   "arn:aws:cloudtrail:${ref.aws_region}:${ref.account_id}:trail/${ref.trail_name}"
+
+steps:
+  - emit:
+      event_type: aws.cloudtrail@v1
+      fields:
+        eventVersion:       "1.08"
+        eventTime:          gen.timestamp()
+        eventID:            gen.uuid()
+        eventSource:        cloudtrail.amazonaws.com
+        eventName:          UpdateTrail
+        eventType:          AwsApiCall
+        eventCategory:      Management
+        awsRegion:          ref.aws_region
+        sourceIPAddress:    ref.source_ip
+        userAgent:          ref.user_agent
+        requestID:          gen.uuid()
+        requestParameters:
+          name:                       ref.trail_name
+          includeGlobalServiceEvents: true
+          isMultiRegionTrail:         true
+        responseElements:
+          name:                       ref.trail_name
+          s3BucketName:               ref.s3_bucket
+          includeGlobalServiceEvents: true
+          isMultiRegionTrail:         true
+          trailARN:                   ref.trail_arn
+          logFileValidationEnabled:   false
+          isOrganizationTrail:        false
+        readOnly:           false
+        managementEvent:    true
+        recipientAccountId: ref.account_id
+        userIdentity:       ref.actor
+        tlsDetails:
+          tlsVersion:               ref.tls_version
+          cipherSuite:              ref.tls_cipher
+          clientProvidedHostHeader: "cloudtrail.${ref.aws_region}.amazonaws.com"


### PR DESCRIPTION

- Introduced `aws-defense-evasion-update-cloudtrail.yaml` validation job to detect use of the `UpdateTrail` API for modifying CloudTrail settings.
- Added `update-trail.yaml` scenario modeling malicious activity and control workloads.
- Includes MITRE ATT&CK defense-evasion coverage for technique T1562.008.